### PR TITLE
link i readme til ci rettet så det peger på codingpirates og ikke lronhoj ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/lronhoj/forenings_medlemmer.svg?style=svg)](https://circleci.com/gh/lronhoj/forenings_medlemmer)
+[![CircleCI](https://circleci.com/gh/CodingPirates/forenings_medlemmer.svg?style=svg)](https://circleci.com/gh/CodingPirates/forenings_medlemmer)
 
 # Coding Pirates' medlems- og tilmeldingssystem
 Medlemssystemet er designet til foreninger  der er organiseret efter DUF modellen. 


### PR DESCRIPTION
Issue #163 - Simpel bugfix - README CI link pegede på min version og ikke den nyoprettede til coding pirates.