### PR TITLE
Make emails case insensitive

### DIFF
--- a/forenings_medlemmer/settings.py
+++ b/forenings_medlemmer/settings.py
@@ -136,6 +136,8 @@ EMAIL_HOST_PASSWORD = 'password'
 EMAIL_USE_TLS = True
 EMAIL_TIMEOUT = 30
 
+AUTHENTICATION_BACKENDS = ('members.backends.CaseInsensitiveModelBackend',)
+
 if DEBUG:
     EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 

--- a/members/backends.py
+++ b/members/backends.py
@@ -1,0 +1,18 @@
+from django.contrib.auth.models import User
+from django.contrib.auth.backends import ModelBackend
+
+
+class CaseInsensitiveModelBackend(ModelBackend):
+    def authenticate(self, username=None, password=None):
+        try:
+            user = User.objects.get(username__iexact=username)
+            if user.check_password(password):
+                return user
+        except User.DoesNotExist:
+            return None
+
+    def get_user(self, user_id):
+        try:
+            return User.objects.get(pk=user_id)
+        except User.DoesNotExist:
+            return None


### PR DESCRIPTION
Dette er vigtigt da mange brugere ved en fejl får skrevet f.eks. første bogstav i brugernavnet med stort i stedet for lille eller omvendt.