### PR TITLE
Config for github actions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,15 @@
+name: Running tests
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup Enviroment 
+        run: cp .env.example .env
+      - name: Builds the stack
+        run: docker-compose build
+      - name: Test
+        run: docker-compose run web ./manage.py test


### PR DESCRIPTION
Opsætter Github actions som vores test runner, tanken er at vi så kan skifte væk fra Circle CI da github er nemmere at administrere og har et bedre interface.

Se [interface eksempel](https://github.com/CodingPirates/forenings_medlemmer/pull/335/checks?check_run_id=321295303)