### PR TITLE
Mundskyld fixdel - oprydning og log ud-side

### DIFF
--- a/members/static/members/sass/base.scss
+++ b/members/static/members/sass/base.scss
@@ -76,6 +76,6 @@ $header_font: 'Bungee', cursive;
     }
 }
 
-.table {
+table {
     word-wrap: break-word;
 }

--- a/members/static/members/sass/base.scss
+++ b/members/static/members/sass/base.scss
@@ -78,4 +78,5 @@ $header_font: 'Bungee', cursive;
 
 table {
     word-wrap: break-word;
+    border: 1px solid #dee2e6!important;
 }

--- a/members/static/members/sass/base.scss
+++ b/members/static/members/sass/base.scss
@@ -75,3 +75,7 @@ $header_font: 'Bungee', cursive;
         color: black;
     }
 }
+
+.table {
+    word-wrap: break-word;
+}

--- a/members/templates/members/activities.html
+++ b/members/templates/members/activities.html
@@ -3,12 +3,13 @@
 {% block content %}
   <div class="container">
       <h1>Aktiviteter</h1>
-      {% if participating or waiting %}
         <h2>Tilmeldte aktiviteter</h2>
         <p>Dette er de aktiviteter jeres børn er tilmeldt. I kan klikke på navnet for hvert arrangement, for at se flere detaljer om hvor og hvornår det foregår. I kan også se deltagerlisten for arrangementet.</p>
         <p>Hvis et arrangement har en rød <kbd>betal</kbd>-knap, er betalingen ikke registreret. Tryk på knappen for at betale.</p>
+        
         <div class="row">
           <div class="col-12">
+            {% if participating or waiting %}
             <section class="card">
               <table class="table table-striped table-responsive">
                 <thead>
@@ -35,17 +36,21 @@
                   {% endfor %}
                 </tbody>
               </table>
-            </section>
+            </section>    
+           {% else %}
+           <div class="alert alert-primary">
+             Der er endnu ingen tilmeldt aktiviteter
+           </div>
+           {% endif %}
           </div>
         </div>
-      {% endif %}
       
       <h2>Invitationer / Åbne aktiviteter</h2>
       <p>Denne liste indeholder invitationer til aktiviteter, hvor der enten er fri tilmelding (først til mølle) eller invitationer til aktiviteter I har stået på venteliste til. I vil modtage en e-mail på e-mail-adressen {{family.email}} når der er aktiviteter, som I kan tilmelde jer.</p>
       <div class="row">
         <div class="col-12">
-          <section class="card">
             {% if invites or waiting_lists or open_activities%}
+            <section class="card">
               <table class="table table-striped table-responsive">
                 <thead>
                   <tr>
@@ -80,12 +85,12 @@
 
                   </tbody>
               </table>
+            </section>
             {% else %}
-              <blockquote class="bg-info">
-                <p>Der er endnu ikke åbnet for tilmelding til aktiviteter. Vi sender en e-mail til {{family.email}} når vi er klar til at modtage tilmeldinger.</p>
-              </blockquote>
+              <div class="alert alert-primary">
+                Der er endnu ikke åbnet for tilmelding til aktiviteter. Vi sender en e-mail til {{family.email}} når vi er klar til at modtage tilmeldinger.
+              </div>
             {% endif %}
-          </section>
         </div>
       </div>
     </div>

--- a/members/templates/members/activities.html
+++ b/members/templates/members/activities.html
@@ -3,96 +3,106 @@
 {% block content %}
   <div class="container">
       <h1>Aktiviteter</h1>
-        <h2>Tilmeldte aktiviteter</h2>
-        <p>Dette er de aktiviteter jeres børn er tilmeldt. I kan klikke på navnet for hvert arrangement, for at se flere detaljer om hvor og hvornår det foregår. I kan også se deltagerlisten for arrangementet.</p>
-        <p>Hvis et arrangement har en rød <kbd>betal</kbd>-knap, er betalingen ikke registreret. Tryk på knappen for at betale.</p>
-        
-        <div class="row">
-          <div class="col-12">
-            {% if participating or waiting %}
-            <section class="card">
-              <table class="table table-striped table-responsive">
-                <thead>
-                  <tr>
-                    <th class="col-sm-3" align="left">Navn</th>
-                    <th>Aktivitet</th>
-                    <th class="col-sm-2">Start</th>
-                    <th class="col-sm-2">Slut</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for participation in participating %}
-                    <tr>
-                      <td>{{participation.member.person.name}}</td>
-                      <td><a href="{%url 'activity_view_person' participation.activity.id participation.member.person.id %}">{{participation.activity.name}} - {{participation.activity.department.name}}</a>
-                      {% if not participation.paid %}
-                      <a class="btn btn-danger" role="button" href="{{participation.get_payment_link}}">Betal</a>
-                      {%endif%}
 
-                      </td>
-                      <td>{{participation.activity.start_date}}</td>
-                      <td>{{participation.activity.end_date}}</td>
-                    </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
-            </section>    
-           {% else %}
-           <div class="alert alert-primary">
-             Der er endnu ingen tilmeldt aktiviteter
-           </div>
-           {% endif %}
-          </div>
+      <h2>Tilmeldte aktiviteter</h2>
+      <p>Dette er de aktiviteter jeres børn er tilmeldt. I kan klikke på navnet for hvert arrangement, for at se flere detaljer om hvor og hvornår det foregår. I kan også se deltagerlisten for arrangementet.</p>
+      <p>Hvis et arrangement har en rød <kbd>betal</kbd>-knap, er betalingen ikke registreret. Tryk på knappen for at betale.</p>
+      {% if participating %}
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Navn</th>
+              <th>Aktivitet</th>
+              <th>Start</th>
+              <th>Slut</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for participation in participating %}
+              <tr>
+                <td>{{participation.member.person.name}}</td>
+                <td>
+                  <a href="{%url 'activity_view_person' participation.activity.id participation.member.person.id %}">{{participation.activity.name}} - {{participation.activity.department.name}}</a>
+                  {% if not participation.paid %}
+                  <a class="btn btn-danger" role="button" href="{{participation.get_payment_link}}">Betal</a>
+                  {%endif%}
+                </td>
+                <td>{{participation.activity.start_date}}</td>
+                <td>{{participation.activity.end_date}}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <div class="alert alert-primary">
+          Der er endnu ingen tilmeldt aktiviteter.
         </div>
+      {% endif %}
       
-      <h2>Invitationer / Åbne aktiviteter</h2>
+      <h2>Invitationer</h2>
       <p>Denne liste indeholder invitationer til aktiviteter, hvor der enten er fri tilmelding (først til mølle) eller invitationer til aktiviteter I har stået på venteliste til. I vil modtage en e-mail på e-mail-adressen {{family.email}} når der er aktiviteter, som I kan tilmelde jer.</p>
-      <div class="row">
-        <div class="col-12">
-            {% if invites or waiting_lists or open_activities%}
-            <section class="card">
-              <table class="table table-striped table-responsive">
-                <thead>
-                  <tr>
-                    <th class="col-3" align="left">Navn</th>
-                    <th class="col-6" align="left">Aktivitet</th>
-                    <th class="col-3 text-left" colspan="2">Reaktion</th>
-                  </tr>
-                </thead>
-                <tbody>
-
-                  {% for activity in open_activities %}
-                      <tr>
-                        <td> - </td>
-                        <td><a href="{%url 'activity_view_family' activity.id %}">{{activity.name}} - <h4><b>Coding Pirates {{activity.department.name}}</b></h4></a></td>
-                          <td>
-                          {% for person in activity.persons %}
-                        <td><a class="btn btn-success" href="{%url 'activity_signup' activity.id person.id %}">Tilmeld {{ person.firstname }} aktivitet</a></td>
-                          {% endfor %}
-                          </td>
-                        <td></td>
-                      </tr>
-                  {% endfor %}
-
-                  {% for invite in invites %}
-                    <tr>
-                      <td>{{invite.person.name}}</td>
-                      <td><a href="{%url 'activity_signup' invite.activity.id invite.person.id %}">{{invite.activity.name}} - <h4><b>{{invite.activity.department.name}}</b></h4></a></td>
-                      <td><a class="btn btn-success" href="{%url 'activity_signup' invite.activity.id invite.person.id %}">Tilmeld aktivitet</a></td>
-                      <td><a class="btn btn-danger" href="{%url 'invitation_decline' family.unique invite.id %}">Afslå</a></td>
-                    </tr>
-                  {% endfor %}
-
-                  </tbody>
-              </table>
-            </section>
-            {% else %}
-              <div class="alert alert-primary">
-                Der er endnu ikke åbnet for tilmelding til aktiviteter. Vi sender en e-mail til {{family.email}} når vi er klar til at modtage tilmeldinger.
-              </div>
-            {% endif %}
+      <p><i>Vær opmærksom på, at du tilmelder dig den rigtige afdeling!</i></p>
+      {% if invites %}
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Navn</th>
+              <th>Aktivitet</th>
+              <th>Reaktion</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for invite in invites %}
+              <tr>
+                <td>{{invite.person.name}}</td>
+                <td><a href="{%url 'activity_signup' invite.activity.id invite.person.id %}">{{invite.activity.name}} hos Coding Pirates {{invite.activity.department.name}}</a></td>
+                <td>
+                  <a class="btn btn-success" href="{%url 'activity_signup' invite.activity.id invite.person.id %}">Tilmeld aktivitet</a>
+                  <a class="btn btn-danger" href="{%url 'invitation_decline' family.unique invite.id %}">Afslå</a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <div class="alert alert-primary">
+          Der er endnu ikke åbnet for tilmelding til aktiviteter. Vi sender en e-mail til {{family.email}} når vi er klar til at modtage tilmeldinger.
         </div>
-      </div>
+      {% endif %}
+
+
+      <h2>Åbne aktiviteter</h2>
+      <p>Denne liste indeholder åbne aktiviteter, hvor der er fri tilmelding</p>
+      {% if open_activities %}
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Afdeling</th>
+              <th>Aktivitet</th>
+              <th>Reaktion</th>
+              <th>Beskrivelse</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for activity in open_activities %}
+              <tr>
+                <td>Coding Pirates {{activity.department.name}}</td>
+                <td>{{activity.name}}</td>
+                <td>
+                  {% for person in activity.persons %}
+                    <a class="btn btn-success" href="{%url 'activity_signup' activity.id person.id %}">Tilmeld {{ person.firstname }} aktivitet</a>
+                  {% endfor %}
+                </td>
+                <td><a class="btn btn-primary" href="{%url 'activity_view_family' activity.id %}" target="_blank">Læs mere</a></td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <div class="alert alert-primary">
+          Der er ikke nogen aktiviteter.
+        </div>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -9,7 +9,7 @@
       <h2>Personer</h2>
       <p>Tryk på <kbd>Opret</kbd>-knapperne, for at tilføje flere personer. Opret gerne begge forældre, så vi kan få fat i jer nemt.</p>
         {% if family.person_set.count > 0 %}
-            <table class="table table-striped table-responsive border" style="display: table; table-layout: fixed;">
+            <table class="table table-striped table-responsive" style="display: table; table-layout: fixed;">
               <thead>
                 <tr>
                   <th class="col-1">Opskrevet</th>

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -8,208 +8,193 @@
 
       <h2>Personer</h2>
       <p>Tryk på <kbd>Opret</kbd>-knapperne, for at tilføje flere personer. Opret gerne begge forældre, så vi kan få fat i jer nemt.</p>
-      <div class="row">
-        <div class="col-12">
-          <section class="card">
-            {% if family.person_set.count > 0 %}
-            <table class="table table-striped table-responsive" style="display: table; table-layout: fixed;">
-              <thead>
+      <section class="card">
+        {% if family.person_set.count > 0 %}
+          <table class="table table-striped table-responsive" style="display: table; table-layout: fixed;">
+            <thead>
+              <tr>
+                <th class="col-1">Opskrevet</th>
+                <th class="col-2">Navn</th>
+                <th class="col-3">Adresse</th>
+                <th class="col-1">Postnr./by</th>
+                <th class="col-2">E-mail</th>
+                <th class="col-1">Telefon</th>
+                <th class="col-2">Handlinger</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for person in ordered_persons %}
                 <tr>
-                  <th class="col-1">Opskrevet</th>
-                  <th class="col-2" align="left">Navn</th>
-                  <th class="col-3" align="left">Adresse</th>
-                  <th class="col-1" align="left">Postnr./by</th>
-                  <th class="col-2" align="left">E-mail</th>
-                  <th class="col-1" align="left">Telefon</th>
-                  <th class="col-2">Handlinger</th>
+                  {%if person.membertype == 'CH' %}
+                  <td><p>{{person.added|date:"d M Y"}}</p>
+                  <p class="text-muted">({{person.added|timesince}} siden)</p></td>
+                  {%else%}
+                  <td></td>
+                  {%endif%}
+
+                  <td><p><b>{{person.name}}</b></p>
+
+                  {%if person.membertype == 'PA' %} <p class="text-muted">(Forælder)</p> {%endif%}
+                  {%if person.membertype == 'GU' %} <p class="text-muted">(Værge)</p> {%endif%}
+                  {%if person.membertype == 'CH' %} <p class="text-muted">(Barn, {{person.age_years}} år)</p> {%endif%}
+                  {%if person.membertype == 'NA' %} <p class="text-muted">(Frivillig)</p> {%endif%}
+
+                  </td>
+
+                  <td><p>{{person.address}}</p></td>
+                  <td><p>{{person.zipcode}} {{person.city}}</p></td>
+                  <td><p>{{person.email}}</p></td>
+                  <td><p>{{person.phone}}</p></td>
+                  <td><p><a type="button" href="{% url 'person_update' person.id %}" class="btn btn-warning">Redigér</a></p></td>
                 </tr>
-              </thead>
-              <tbody>
-                {% for person in ordered_persons %}
-                  <tr>
-                    {%if person.membertype == 'CH' %}
-                    <td><p>{{person.added|date:"d M Y"}}</p>
-                    <p class="text-muted">({{person.added|timesince}} siden)</p></td>
-                    {%else%}
-                    <td></td>
-                    {%endif%}
-
-                    <td><p><b>{{person.name}}</b></p>
-
-                    {%if person.membertype == 'PA' %} <p class="text-muted">(Forælder)</p> {%endif%}
-                    {%if person.membertype == 'GU' %} <p class="text-muted">(Værge)</p> {%endif%}
-                    {%if person.membertype == 'CH' %} <p class="text-muted">(Barn, {{person.age_years}} år)</p> {%endif%}
-                    {%if person.membertype == 'NA' %} <p class="text-muted">(Frivillig)</p> {%endif%}
-
-                    </td>
-
-                    <td><p>{{person.address}}</p></td>
-                    <td><p>{{person.zipcode}} {{person.city}}</p></td>
-                    <td><p>{{person.email}}</p></td>
-                    <td><p>{{person.phone}}</p></td>
-                    <td><p><a type="button" href="{% url 'person_update' person.id %}" class="btn btn-warning">Redigér</a></p></td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-            {% endif %}
-          </section>
-          <br>
-          <a class="btn btn-primary" role="button" href="{% url 'person_add' 'CH' %}">Opret barn</a>
-          <a class="btn btn-primary" role="button" href="{% url 'person_add' 'PA' %}">Opret forælder</a>
-          <a class="btn btn-primary" role="button" href="{% url 'person_add' 'GU' %}">Opret værge</a>
-          <br>
-          <br>
-          {%if request_parents %}
-          <blockquote class="bg-warning">
-            <p>Opret mindst 1 forælder / værge med kontaktoplysninger, så vi i Coding Pirates nemt kan få fat i jer.</p>
-          </blockquote>
-          {%endif%}
-          {% if need_confirmation %}
-          <blockquote class="bg-danger">
-          <p> Det er længe siden du sidst bekræftede dine oplysninger. <a class="btn btn-success" href="{% url 'confirm_details' %}">Bekræft oplysninger</a>
-          </blockquote>
-          {%endif%}
+              {% endfor %}
+            </tbody>
+          </table>
+        {% endif %}
+      </section>
+      <br>
+      <a class="btn btn-primary" role="button" href="{% url 'person_add' 'CH' %}">Opret barn</a>
+      <a class="btn btn-primary" role="button" href="{% url 'person_add' 'PA' %}">Opret forælder</a>
+      <a class="btn btn-primary" role="button" href="{% url 'person_add' 'GU' %}">Opret værge</a>
+      <br>
+      <br>
+      {%if request_parents %}
+        <div class="alert alert-danger">
+          <p>Opret mindst 1 forælder / værge med kontaktoplysninger, så vi i Coding Pirates nemt kan få fat i jer.</p>
         </div>
-      </div>
+      {%endif%}
+      {% if need_confirmation %}
+        <div class="alert alert-danger">
+          Det er længe siden du sidst bekræftede dine oplysninger. <a class="btn btn-success" href="{% url 'confirm_details' %}">Bekræft oplysninger</a>
+        </div>
+      {%endif%}
 
       {% if participating or waiting %}
       <h2>Tilmeldte aktiviteter</h2>
       <p>Dette er de aktiviteter jeres børn er tilmeldt. I kan klikke på navnet for hvert arrangement, for at se flere detaljer om hvor og hvornår det foregår. I kan også se deltagerlisten for arrangementet.</p>
       <p>Hvis et arrangement har en rød <kbd>betal</kbd>-knap, er betalingen ikke registreret. Tryk på knappen for at betale.</p>
-      <div class="row">
-        <div class="col-12">
-          <section class="card">
-            <table class="table table-striped table-responsive">
-              <thead>
-                <tr>
-                  <th class="col-sm-3" align="left">Navn</th>
-                  <th>Aktivitet</th>
-                  <th class="col-sm-2">Start</th>
-                  <th class="col-sm-2">Slut</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for participation in participating %}
-                  <tr>
-                    <td>{{participation.member.person.name}}</td>
-                    <td><a href="{%url 'activity_view_person' participation.activity.id participation.member.person.id %}">{{participation.activity.name}} - {{participation.activity.department.name}}</a>
-                    {% if not participation.paid %}
-                    <a class="btn btn-danger" role="button" href="{{participation.get_payment_link}}">Betal</a>
-                    {%endif%}
+      <section class="card">
+        <table class="table table-striped table-responsive">
+          <thead>
+            <tr>
+              <th class="col-sm-3">Navn</th>
+              <th>Aktivitet</th>
+              <th class="col-sm-2">Start</th>
+              <th class="col-sm-2">Slut</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for participation in participating %}
+              <tr>
+                <td>{{participation.member.person.name}}</td>
+                <td><a href="{%url 'activity_view_person' participation.activity.id participation.member.person.id %}">{{participation.activity.name}} - {{participation.activity.department.name}}</a>
+                {% if not participation.paid %}
+                <a class="btn btn-danger" role="button" href="{{participation.get_payment_link}}">Betal</a>
+                {%endif%}
 
-                    </td>
-                    <td>{{participation.activity.start_date}}</td>
-                    <td>{{participation.activity.end_date}}</td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </section>
-        </div>
-      </div>
+                </td>
+                <td>{{participation.activity.start_date}}</td>
+                <td>{{participation.activity.end_date}}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </section>
       {% endif %}
 
       <h2>Invitationer / Åbne aktiviteter</h2>
       <p>Denne liste indeholder invitationer til aktiviteter, hvor der enten er fri tilmelding (først til mølle) eller invitationer til aktiviteter I har stået på venteliste til. I vil modtage en e-mail på e-mail-adressen {{family.email}} når der er aktiviteter, som I kan tilmelde jer.</p>
-      <div class="row">
-        <div class="col-12">
-          <section class="card">
-            {% if invites or waiting_lists or open_activities%}
-              <table class="table table-striped table-responsive">
-                <thead>
+      {% if invites or waiting_lists or open_activities%}
+        <section class="card">
+          <table class="table table-striped table-responsive">
+            <thead>
+              <tr>
+                <th>Navn</th>
+                <th>Aktivitet</th>
+                <th class="text-left" colspan="2">Reaktion</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for invite in invites %}
+                <tr>
+                  <td>{{invite.person.name}}</td>
+                  <td><a href="{%url 'activity_signup' invite.activity.id invite.person.id %}">{{invite.activity.name}} - <h4><b>{{invite.activity.department.name}}</b></h4></a></td>
+                  <td><a class="btn btn-success" href="{%url 'activity_signup' invite.activity.id invite.person.id %}">Tilmeld aktivitet</a></td>
+                  <td><a class="btn btn-danger" href="{%url 'invitation_decline' family.unique invite.id %}">Afslå</a></td>
+                </tr>
+              {% endfor %}
+
+              {% for activity in open_activities %}
                   <tr>
-                    <th align="left">Navn</th>
-                    <th align="left">Aktivitet</th>
-                    <th class="text-left" colspan="2">Reaktion</th>
+                    <td> - </td>
+                    <td><a href="{%url 'activity_view_family' activity.id %}">{{activity.name}} - <h4><b>Coding Pirates {{activity.department.name}}</b></h4></a></td>
+                      <td>
+                      {% for person in activity.persons %}
+                    <td><a class="btn btn-success" href="{%url 'activity_signup' activity.id person.id %}">Tilmeld {{ person.firstname }} aktivitet</a></td>
+                      {% endfor %}
+                      </td>
+                    <td></td>
                   </tr>
-                </thead>
-                <tbody>
-                  {% for invite in invites %}
-                    <tr>
-                      <td>{{invite.person.name}}</td>
-                      <td><a href="{%url 'activity_signup' invite.activity.id invite.person.id %}">{{invite.activity.name}} - <h4><b>{{invite.activity.department.name}}</b></h4></a></td>
-                      <td><a class="btn btn-success" href="{%url 'activity_signup' invite.activity.id invite.person.id %}">Tilmeld aktivitet</a></td>
-                      <td><a class="btn btn-danger" href="{%url 'invitation_decline' family.unique invite.id %}">Afslå</a></td>
-                    </tr>
-                  {% endfor %}
+              {% endfor %}
 
-                  {% for activity in open_activities %}
-                      <tr>
-                        <td> - </td>
-                        <td><a href="{%url 'activity_view_family' activity.id %}">{{activity.name}} - <h4><b>Coding Pirates {{activity.department.name}}</b></h4></a></td>
-                          <td>
-                          {% for person in activity.persons %}
-                        <td><a class="btn btn-success" href="{%url 'activity_signup' activity.id person.id %}">Tilmeld {{ person.firstname }} aktivitet</a></td>
-                          {% endfor %}
-                          </td>
-                        <td></td>
-                      </tr>
-                  {% endfor %}
-
-                  </tbody>
-              </table>
-            {% else %}
-              <blockquote class="bg-info">
-              <p>Der er endnu ikke åbnet for tilmelding til aktiviteter. Vi sender en e-mail til {{family.email}} når vi er klar til at modtage tilmeldinger.</p>
-            </blockquote>
-            {% endif %}
-          </section>
+              </tbody>
+          </table>
+        </section>
+      {% else %}
+        <div class="alert alert-primary">
+          Der er endnu ikke åbnet for tilmelding til aktiviteter. Vi sender en e-mail til {{family.email}} når vi er klar til at modtage tilmeldinger.
         </div>
-      </div>
+      {% endif %}
 
       <h2>Ventelister</h2>
       <p>Tryk på <kbd>Opskriv</kbd> knapperne for hver afdeling der har interesse for jer. Bemærk at jeres position på ventelisten afgøres ud fra barnets oprettelses tidspunkt i systemet (datoen "Opskrevet" i Personer) - <i> ikke tidspunktet i melder jeg på ventelisterne nedenfor! - </i> I kan derfor frit tilmelde og framelde jer ventelisterne uden at frygte i mister jeres position på listen.</p>
       <p>Tryk på <kbd>Afmeld</kbd> knapperne for at forlade en afdelings ventelisten igen.</p>
       <p>Opret jer kun på de lister der har interesse for jer. Det er en god ide at kigge forbi hyppigt op til sæsonstart, da vi tilføjer nye afdelinger efterhånden som vi får bekræftet de åbner og børnene får kun tilbud om at komme med på de afdelinger de har skrevet sig op til.</p>
       <h3><a href="{% url 'family_waitinglist_view' %}">Se jeres nuværende position på ventelisterne</a></h3>
-      <div class="row">
-        <div class="col-12">
-          <section class="card">
-            {% if department_children_waiting %}
-              <table class="table table-striped table-responsive">
-                <thead>
-                  <tr>
-                    <th class="col-2" align="left">Navn</th>
-                    <th class="col-2" align="left">Adresse</th>
-                    <th class="col-2" align="left">Åbningstid</th>
-                    <th class="col-3" align="right">Ikke tilmeldt ventelisten<br/>på denne afdeling</th>
-                    <th class="col-3" align="right">Tilmeldt ventelisten<br/>på denne afdeling</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for key, department in department_children_waiting.departments.items %}
-                    <tr>
-                      <td>Coding Pirates {{department.object.name}}</td>
-                      <td><p>{{department.object.address}}</p> <p>{{department.object.zipcode}} {{department.object.city}}</p></td>
-                      <td>{{department.object.open_hours}}</td>
-                      <td>
-                      {%for key, child in department.children_status.items %}
-                        {%if not child.waiting %}
-                          <a class="btn btn-success" href="{% url 'waiting_list_subscription' child.object.id department.object.id 'subscribe' %}">Opskriv: {{child.firstname}}</a>
-                        {%endif%}
-                      {%endfor%}
-                      </td>
-                      <td>
-                      {%for key, child in department.children_status.items %}
-                        {%if child.waiting %}
-                          <a class="btn btn-danger" href="{% url 'waiting_list_subscription' child.object.id department.object.id 'unsubscribe' %}">Afmeld: {{child.firstname}}</a>
-                        {%endif%}
-                      {%endfor%}
-                      </td>
-                      <td></td>
-                    </tr>
-                  {% endfor %}
+      <section class="card">
+        {% if department_children_waiting %}
+          <table class="table table-striped table-responsive">
+            <thead>
+              <tr>
+                <th>Navn</th>
+                <th>Adresse</th>
+                <th>Åbningstid</th>
+                <th>Ikke tilmeldt ventelisten<br/>på denne afdeling</th>
+                <th>Tilmeldt ventelisten<br/>på denne afdeling</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for key, department in department_children_waiting.departments.items %}
+                <tr>
+                  <td>Coding Pirates {{department.object.name}}</td>
+                  <td><p>{{department.object.address}}</p> <p>{{department.object.zipcode}} {{department.object.city}}</p></td>
+                  <td>{{department.object.open_hours}}</td>
+                  <td>
+                  {%for key, child in department.children_status.items %}
+                    {%if not child.waiting %}
+                      <a class="btn btn-success" href="{% url 'waiting_list_subscription' child.object.id department.object.id 'subscribe' %}">Opskriv: {{child.firstname}}</a>
+                    {%endif%}
+                  {%endfor%}
+                  </td>
+                  <td>
+                  {%for key, child in department.children_status.items %}
+                    {%if child.waiting %}
+                      <a class="btn btn-danger" href="{% url 'waiting_list_subscription' child.object.id department.object.id 'unsubscribe' %}">Afmeld: {{child.firstname}}</a>
+                    {%endif%}
+                  {%endfor%}
+                  </td>
+                  <td></td>
+                </tr>
+              {% endfor %}
 
-                  </tbody>
-              </table>
-            {% else %}
-                <div class="col-12">Der er ingen aktuelle ventelister.
-                </div>
-            {% endif %}
-          </section>
-        </div>
-      </div>
+              </tbody>
+          </table>
+        {% else %}
+            <div class="alert alert-primary">
+              Der er ingen aktuelle ventelister.
+            </div>
+        {% endif %}
+      </section>
     </div>
   </div>
 {% endblock %}

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -160,7 +160,7 @@
                   {% for key, department in department_children_waiting.departments.items %}
                     <tr>
                       <td>Coding Pirates {{department.object.name}}</td>
-                      <td><p>{{department.object.address}}</p> <p>{{department.object.zipcode}} {{department.object.city}}</p></td>
+                      <td>{{department.object.address}}<br/>{{department.object.zipcode}} {{department.object.city}}</td>
                       <td>{{department.object.open_hours}}</td>
                       <td>
                       {%for key, child in department.children_status.items %}
@@ -187,6 +187,5 @@
                   Der er ingen aktuelle ventelister.
                 </div>
             {% endif %}
-    </div>
   </div>
 {% endblock %}

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -8,9 +8,8 @@
 
       <h2>Personer</h2>
       <p>Tryk på <kbd>Opret</kbd>-knapperne, for at tilføje flere personer. Opret gerne begge forældre, så vi kan få fat i jer nemt.</p>
-      <div class="border">
         {% if family.person_set.count > 0 %}
-            <table class="table table-striped table-responsive" style="display: table; table-layout: fixed;">
+            <table class="table table-striped table-responsive border" style="display: table; table-layout: fixed;">
               <thead>
                 <tr>
                   <th class="col-1">Opskrevet</th>
@@ -51,7 +50,6 @@
               </tbody>
             </table>
           {% endif %}
-          </div>
           <br>
           <a class="btn btn-primary" role="button" href="{% url 'person_add' 'CH' %}">Opret barn</a>
           <a class="btn btn-primary" role="button" href="{% url 'person_add' 'PA' %}">Opret forælder</a>

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -10,137 +10,137 @@
       <p>Tryk på <kbd>Opret</kbd>-knapperne, for at tilføje flere personer. Opret gerne begge forældre, så vi kan få fat i jer nemt.</p>
       <div class="border">
         {% if family.person_set.count > 0 %}
-          <table class="table table-striped table-responsive" style="display: table; table-layout: fixed;">
-            <thead>
-              <tr>
-                <th class="col-1">Opskrevet</th>
-                <th class="col-2">Navn</th>
-                <th class="col-3">Adresse</th>
-                <th class="col-1">Postnr./by</th>
-                <th class="col-2">E-mail</th>
-                <th class="col-1">Telefon</th>
-                <th class="col-2">Handlinger</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for person in ordered_persons %}
+            <table class="table table-striped table-responsive" style="display: table; table-layout: fixed;">
+              <thead>
                 <tr>
-                  {%if person.membertype == 'CH' %}
-                  <td><p>{{person.added|date:"d M Y"}}</p>
-                  <p class="text-muted">({{person.added|timesince}} siden)</p></td>
-                  {%else%}
-                  <td></td>
-                  {%endif%}
-
-                  <td><p><b>{{person.name}}</b></p>
-
-                  {%if person.membertype == 'PA' %} <p class="text-muted">(Forælder)</p> {%endif%}
-                  {%if person.membertype == 'GU' %} <p class="text-muted">(Værge)</p> {%endif%}
-                  {%if person.membertype == 'CH' %} <p class="text-muted">(Barn, {{person.age_years}} år)</p> {%endif%}
-                  {%if person.membertype == 'NA' %} <p class="text-muted">(Frivillig)</p> {%endif%}
-
-                  </td>
-
-                  <td><p>{{person.address}}</p></td>
-                  <td><p>{{person.zipcode}} {{person.city}}</p></td>
-                  <td><p>{{person.email}}</p></td>
-                  <td><p>{{person.phone}}</p></td>
-                  <td><p><a type="button" href="{% url 'person_update' person.id %}" class="btn btn-warning">Redigér</a></p></td>
+                  <th class="col-1">Opskrevet</th>
+                  <th class="col-2">Navn</th>
+                  <th class="col-3">Adresse</th>
+                  <th class="col-1">Postnr./by</th>
+                  <th class="col-2">E-mail</th>
+                  <th class="col-1">Telefon</th>
+                  <th class="col-2">Handlinger</th>
                 </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        {% endif %}
-        </div>
-      <br>
-      <a class="btn btn-primary" role="button" href="{% url 'person_add' 'CH' %}">Opret barn</a>
-      <a class="btn btn-primary" role="button" href="{% url 'person_add' 'PA' %}">Opret forælder</a>
-      <a class="btn btn-primary" role="button" href="{% url 'person_add' 'GU' %}">Opret værge</a>
-      <br>
-      <br>
-      {%if request_parents %}
-        <div class="alert alert-danger">
-          <p>Opret mindst 1 forælder / værge med kontaktoplysninger, så vi i Coding Pirates nemt kan få fat i jer.</p>
-        </div>
-      {%endif%}
-      {% if need_confirmation %}
-        <div class="alert alert-danger">
-          Det er længe siden du sidst bekræftede dine oplysninger. <a class="btn btn-success" href="{% url 'confirm_details' %}">Bekræft oplysninger</a>
-        </div>
-      {%endif%}
+              </thead>
+              <tbody>
+                {% for person in ordered_persons %}
+                  <tr>
+                    {%if person.membertype == 'CH' %}
+                    <td><p>{{person.added|date:"d M Y"}}</p>
+                    <p class="text-muted">({{person.added|timesince}} siden)</p></td>
+                    {%else%}
+                    <td></td>
+                    {%endif%}
+
+                    <td><p><b>{{person.name}}</b></p>
+
+                    {%if person.membertype == 'PA' %} <p class="text-muted">(Forælder)</p> {%endif%}
+                    {%if person.membertype == 'GU' %} <p class="text-muted">(Værge)</p> {%endif%}
+                    {%if person.membertype == 'CH' %} <p class="text-muted">(Barn, {{person.age_years}} år)</p> {%endif%}
+                    {%if person.membertype == 'NA' %} <p class="text-muted">(Frivillig)</p> {%endif%}
+
+                    </td>
+
+                    <td><p>{{person.address}}</p></td>
+                    <td><p>{{person.zipcode}} {{person.city}}</p></td>
+                    <td><p>{{person.email}}</p></td>
+                    <td><p>{{person.phone}}</p></td>
+                    <td><p><a type="button" href="{% url 'person_update' person.id %}" class="btn btn-warning">Redigér</a></p></td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          {% endif %}
+          </div>
+          <br>
+          <a class="btn btn-primary" role="button" href="{% url 'person_add' 'CH' %}">Opret barn</a>
+          <a class="btn btn-primary" role="button" href="{% url 'person_add' 'PA' %}">Opret forælder</a>
+          <a class="btn btn-primary" role="button" href="{% url 'person_add' 'GU' %}">Opret værge</a>
+          <br>
+          <br>
+          {%if request_parents %}
+          <div class="alert alert-danger">
+            Opret mindst 1 forælder / værge med kontaktoplysninger, så vi i Coding Pirates nemt kan få fat i jer.
+          </div>
+          {%endif%}
+          {% if need_confirmation %}
+          <div class="alert alert-danger">
+            Det er længe siden du sidst bekræftede dine oplysninger. <a class="btn btn-success" href="{% url 'confirm_details' %}">Bekræft oplysninger</a>
+          </div>
+          {%endif%}
 
       {% if participating or waiting %}
       <h2>Tilmeldte aktiviteter</h2>
       <p>Dette er de aktiviteter jeres børn er tilmeldt. I kan klikke på navnet for hvert arrangement, for at se flere detaljer om hvor og hvornår det foregår. I kan også se deltagerlisten for arrangementet.</p>
       <p>Hvis et arrangement har en rød <kbd>betal</kbd>-knap, er betalingen ikke registreret. Tryk på knappen for at betale.</p>
-        <table class="table table-striped table-responsive">
-          <thead>
-            <tr>
-              <th class="col-sm-3">Navn</th>
-              <th>Aktivitet</th>
-              <th class="col-sm-2">Start</th>
-              <th class="col-sm-2">Slut</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for participation in participating %}
-              <tr>
-                <td>{{participation.member.person.name}}</td>
-                <td><a href="{%url 'activity_view_person' participation.activity.id participation.member.person.id %}">{{participation.activity.name}} - {{participation.activity.department.name}}</a>
-                {% if not participation.paid %}
-                <a class="btn btn-danger" role="button" href="{{participation.get_payment_link}}">Betal</a>
-                {%endif%}
+            <table class="table table-striped table-responsive">
+              <thead>
+                <tr>
+                  <th class="col-sm-3">Navn</th>
+                  <th>Aktivitet</th>
+                  <th class="col-sm-2">Start</th>
+                  <th class="col-sm-2">Slut</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for participation in participating %}
+                  <tr>
+                    <td>{{participation.member.person.name}}</td>
+                    <td><a href="{%url 'activity_view_person' participation.activity.id participation.member.person.id %}">{{participation.activity.name}} - {{participation.activity.department.name}}</a>
+                    {% if not participation.paid %}
+                    <a class="btn btn-danger" role="button" href="{{participation.get_payment_link}}">Betal</a>
+                    {%endif%}
 
-                </td>
-                <td>{{participation.activity.start_date}}</td>
-                <td>{{participation.activity.end_date}}</td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+                    </td>
+                    <td>{{participation.activity.start_date}}</td>
+                    <td>{{participation.activity.end_date}}</td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
       {% endif %}
 
       <h2>Invitationer / Åbne aktiviteter</h2>
       <p>Denne liste indeholder invitationer til aktiviteter, hvor der enten er fri tilmelding (først til mølle) eller invitationer til aktiviteter I har stået på venteliste til. I vil modtage en e-mail på e-mail-adressen {{family.email}} når der er aktiviteter, som I kan tilmelde jer.</p>
       {% if invites or waiting_lists or open_activities%}
-          <table class="table table-striped table-responsive">
-            <thead>
-              <tr>
-                <th>Navn</th>
-                <th>Aktivitet</th>
-                <th class="text-left" colspan="2">Reaktion</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for invite in invites %}
-                <tr>
-                  <td>{{invite.person.name}}</td>
-                  <td><a href="{%url 'activity_signup' invite.activity.id invite.person.id %}">{{invite.activity.name}} - <h4><b>{{invite.activity.department.name}}</b></h4></a></td>
-                  <td><a class="btn btn-success" href="{%url 'activity_signup' invite.activity.id invite.person.id %}">Tilmeld aktivitet</a></td>
-                  <td><a class="btn btn-danger" href="{%url 'invitation_decline' family.unique invite.id %}">Afslå</a></td>
-                </tr>
-              {% endfor %}
-
-              {% for activity in open_activities %}
+              <table class="table table-striped table-responsive">
+                <thead>
                   <tr>
-                    <td> - </td>
-                    <td><a href="{%url 'activity_view_family' activity.id %}">{{activity.name}} - <h4><b>Coding Pirates {{activity.department.name}}</b></h4></a></td>
-                      <td>
-                      {% for person in activity.persons %}
-                    <td><a class="btn btn-success" href="{%url 'activity_signup' activity.id person.id %}">Tilmeld {{ person.firstname }} aktivitet</a></td>
-                      {% endfor %}
-                      </td>
-                    <td></td>
+                    <th>Navn</th>
+                    <th>Aktivitet</th>
+                    <th class="text-left" colspan="2">Reaktion</th>
                   </tr>
-              {% endfor %}
+                </thead>
+                <tbody>
+                  {% for invite in invites %}
+                    <tr>
+                      <td>{{invite.person.name}}</td>
+                      <td><a href="{%url 'activity_signup' invite.activity.id invite.person.id %}">{{invite.activity.name}} - <h4><b>{{invite.activity.department.name}}</b></h4></a></td>
+                      <td><a class="btn btn-success" href="{%url 'activity_signup' invite.activity.id invite.person.id %}">Tilmeld aktivitet</a></td>
+                      <td><a class="btn btn-danger" href="{%url 'invitation_decline' family.unique invite.id %}">Afslå</a></td>
+                    </tr>
+                  {% endfor %}
 
-              </tbody>
-          </table>
-      {% else %}
-        <div class="alert alert-primary">
-          Der er endnu ikke åbnet for tilmelding til aktiviteter. Vi sender en e-mail til {{family.email}} når vi er klar til at modtage tilmeldinger.
-        </div>
-      {% endif %}
+                  {% for activity in open_activities %}
+                      <tr>
+                        <td> - </td>
+                        <td><a href="{%url 'activity_view_family' activity.id %}">{{activity.name}} - <h4><b>Coding Pirates {{activity.department.name}}</b></h4></a></td>
+                          <td>
+                          {% for person in activity.persons %}
+                        <td><a class="btn btn-success" href="{%url 'activity_signup' activity.id person.id %}">Tilmeld {{ person.firstname }} aktivitet</a></td>
+                          {% endfor %}
+                          </td>
+                        <td></td>
+                      </tr>
+                  {% endfor %}
+
+                  </tbody>
+              </table>
+            {% else %}
+              <div class="alert alert-primary">
+                Der er endnu ikke åbnet for tilmelding til aktiviteter. Vi sender en e-mail til {{family.email}} når vi er klar til at modtage tilmeldinger.
+              </div>
+            {% endif %}
 
       <h2>Ventelister</h2>
       <p>Tryk på <kbd>Opskriv</kbd> knapperne for hver afdeling der har interesse for jer. Bemærk at jeres position på ventelisten afgøres ud fra barnets oprettelses tidspunkt i systemet (datoen "Opskrevet" i Personer) - <i> ikke tidspunktet i melder jeg på ventelisterne nedenfor! - </i> I kan derfor frit tilmelde og framelde jer ventelisterne uden at frygte i mister jeres position på listen.</p>
@@ -148,47 +148,47 @@
       <p>Opret jer kun på de lister der har interesse for jer. Det er en god ide at kigge forbi hyppigt op til sæsonstart, da vi tilføjer nye afdelinger efterhånden som vi får bekræftet de åbner og børnene får kun tilbud om at komme med på de afdelinger de har skrevet sig op til.</p>
       <h3><a href="{% url 'family_waitinglist_view' %}">Se jeres nuværende position på ventelisterne</a></h3>
         {% if department_children_waiting %}
-          <table class="table table-striped table-responsive">
-            <thead>
-              <tr>
-                <th>Navn</th>
-                <th>Adresse</th>
-                <th>Åbningstid</th>
-                <th>Ikke tilmeldt ventelisten<br/>på denne afdeling</th>
-                <th>Tilmeldt ventelisten<br/>på denne afdeling</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for key, department in department_children_waiting.departments.items %}
-                <tr>
-                  <td>Coding Pirates {{department.object.name}}</td>
-                  <td><p>{{department.object.address}}</p> <p>{{department.object.zipcode}} {{department.object.city}}</p></td>
-                  <td>{{department.object.open_hours}}</td>
-                  <td>
-                  {%for key, child in department.children_status.items %}
-                    {%if not child.waiting %}
-                      <a class="btn btn-success" href="{% url 'waiting_list_subscription' child.object.id department.object.id 'subscribe' %}">Opskriv: {{child.firstname}}</a>
-                    {%endif%}
-                  {%endfor%}
-                  </td>
-                  <td>
-                  {%for key, child in department.children_status.items %}
-                    {%if child.waiting %}
-                      <a class="btn btn-danger" href="{% url 'waiting_list_subscription' child.object.id department.object.id 'unsubscribe' %}">Afmeld: {{child.firstname}}</a>
-                    {%endif%}
-                  {%endfor%}
-                  </td>
-                  <td></td>
-                </tr>
-              {% endfor %}
+              <table class="table table-striped table-responsive">
+                <thead>
+                  <tr>
+                    <th>Navn</th>
+                    <th>Adresse</th>
+                    <th>Åbningstid</th>
+                    <th>Ikke tilmeldt ventelisten<br/>på denne afdeling</th>
+                    <th>Tilmeldt ventelisten<br/>på denne afdeling</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for key, department in department_children_waiting.departments.items %}
+                    <tr>
+                      <td>Coding Pirates {{department.object.name}}</td>
+                      <td><p>{{department.object.address}}</p> <p>{{department.object.zipcode}} {{department.object.city}}</p></td>
+                      <td>{{department.object.open_hours}}</td>
+                      <td>
+                      {%for key, child in department.children_status.items %}
+                        {%if not child.waiting %}
+                          <a class="btn btn-success" href="{% url 'waiting_list_subscription' child.object.id department.object.id 'subscribe' %}">Opskriv: {{child.firstname}}</a>
+                        {%endif%}
+                      {%endfor%}
+                      </td>
+                      <td>
+                      {%for key, child in department.children_status.items %}
+                        {%if child.waiting %}
+                          <a class="btn btn-danger" href="{% url 'waiting_list_subscription' child.object.id department.object.id 'unsubscribe' %}">Afmeld: {{child.firstname}}</a>
+                        {%endif%}
+                      {%endfor%}
+                      </td>
+                      <td></td>
+                    </tr>
+                  {% endfor %}
 
-              </tbody>
-          </table>
-        {% else %}
-            <div class="alert alert-primary">
-              Der er ingen aktuelle ventelister.
-            </div>
-        {% endif %}
+                  </tbody>
+              </table>
+            {% else %}
+                <div class="alert alert-primary">
+                  Der er ingen aktuelle ventelister.
+                </div>
+            {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -73,21 +73,21 @@
             <table class="table table-striped">
               <thead>
                 <tr>
-                  <th class="col-sm-3">Navn</th>
+                  <th>Navn</th>
                   <th>Aktivitet</th>
-                  <th class="col-sm-2">Start</th>
-                  <th class="col-sm-2">Slut</th>
+                  <th>Start</th>
+                  <th>Slut</th>
                 </tr>
               </thead>
               <tbody>
                 {% for participation in participating %}
                   <tr>
                     <td>{{participation.member.person.name}}</td>
-                    <td><a href="{%url 'activity_view_person' participation.activity.id participation.member.person.id %}">{{participation.activity.name}} - {{participation.activity.department.name}}</a>
-                    {% if not participation.paid %}
-                    <a class="btn btn-danger" role="button" href="{{participation.get_payment_link}}">Betal</a>
-                    {%endif%}
-
+                    <td>
+                      <a href="{%url 'activity_view_person' participation.activity.id participation.member.person.id %}">{{participation.activity.name}} - {{participation.activity.department.name}}</a>
+                      {% if not participation.paid %}
+                      <a class="btn btn-danger" role="button" href="{{participation.get_payment_link}}">Betal</a>
+                      {%endif%}
                     </td>
                     <td>{{participation.activity.start_date}}</td>
                     <td>{{participation.activity.end_date}}</td>

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -1,7 +1,6 @@
 {% extends 'members/base.html' %}
 
 {% block content %}
-  <div class="container">
       <h1>Familiedetaljer</h1>
       <p>Velkommen til Coding Pirates' medlemssystem. Du ser nu oversigten over de oplysninger vi har registreret om jeres familie. Det er vigtigt du sikrer dig at oplysningerne er korrekte. Din familie er registreret på e-mail-adressen <a class="text-info">{{family.email}}</a>, hvilket også er denne vi sender informationer til dig om tilmeding til hold og aktiviteter.</p>
       <p>For yderligere hjælp med at bruge denne side - se på <a href="http://codingpirates.dk/crmhjaelp/">"Sådan bruger du vores medlemssystem"</a> eller skriv til os på <a href="mailto:kontakt@codingpirates.dk">kontakt@codingpirates.dk</a>.</p>
@@ -187,5 +186,4 @@
                   Der er ingen aktuelle ventelister.
                 </div>
             {% endif %}
-  </div>
 {% endblock %}

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -97,47 +97,70 @@
             </table>
       {% endif %}
 
-      <h2>Invitationer / Åbne aktiviteter</h2>
+      <h2>Invitationer</h2>
       <p>Denne liste indeholder invitationer til aktiviteter, hvor der enten er fri tilmelding (først til mølle) eller invitationer til aktiviteter I har stået på venteliste til. I vil modtage en e-mail på e-mail-adressen {{family.email}} når der er aktiviteter, som I kan tilmelde jer.</p>
-      {% if invites or waiting_lists or open_activities%}
+      <p><i>Vær opmærksom på, at du tilmelder dig den rigtige afdeling!</i></p>
+      {% if invites %}
               <table class="table table-striped">
                 <thead>
                   <tr>
                     <th>Navn</th>
                     <th>Aktivitet</th>
-                    <th class="text-left" colspan="2">Reaktion</th>
+                    <th>Reaktion</th>
                   </tr>
                 </thead>
                 <tbody>
                   {% for invite in invites %}
                     <tr>
                       <td>{{invite.person.name}}</td>
-                      <td><a href="{%url 'activity_signup' invite.activity.id invite.person.id %}">{{invite.activity.name}} - <h4><b>{{invite.activity.department.name}}</b></h4></a></td>
-                      <td><a class="btn btn-success" href="{%url 'activity_signup' invite.activity.id invite.person.id %}">Tilmeld aktivitet</a></td>
-                      <td><a class="btn btn-danger" href="{%url 'invitation_decline' family.unique invite.id %}">Afslå</a></td>
+                      <td><a href="{%url 'activity_signup' invite.activity.id invite.person.id %}">{{invite.activity.name}} hos Coding Pirates {{invite.activity.department.name}}</a></td>
+                      <td>
+                        <a class="btn btn-success" href="{%url 'activity_signup' invite.activity.id invite.person.id %}">Tilmeld aktivitet</a>
+                        <a class="btn btn-danger" href="{%url 'invitation_decline' family.unique invite.id %}">Afslå</a>
+                      </td>
                     </tr>
                   {% endfor %}
-
-                  {% for activity in open_activities %}
-                      <tr>
-                        <td> - </td>
-                        <td><a href="{%url 'activity_view_family' activity.id %}">{{activity.name}} - <h4><b>Coding Pirates {{activity.department.name}}</b></h4></a></td>
-                          <td>
-                          {% for person in activity.persons %}
-                        <td><a class="btn btn-success" href="{%url 'activity_signup' activity.id person.id %}">Tilmeld {{ person.firstname }} aktivitet</a></td>
-                          {% endfor %}
-                          </td>
-                        <td></td>
-                      </tr>
-                  {% endfor %}
-
-                  </tbody>
+                </tbody>
               </table>
             {% else %}
               <div class="alert alert-primary">
                 Der er endnu ikke åbnet for tilmelding til aktiviteter. Vi sender en e-mail til {{family.email}} når vi er klar til at modtage tilmeldinger.
               </div>
             {% endif %}
+
+
+      <h2>Åbne aktiviteter</h2>
+      <p>Denne liste indeholder åbne aktiviteter, hvor der er fri tilmelding</p>
+      {% if open_activities %}
+        <table class="table table-striped">
+          <thead>
+            <tr>
+              <th>Afdeling</th>
+              <th>Aktivitet</th>
+              <th>Reaktion</th>
+              <th>Beskrivelse</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for activity in open_activities %}
+              <tr>
+                <td>Coding Pirates {{activity.department.name}}</td>
+                <td>{{activity.name}}</td>
+                <td>
+                  {% for person in activity.persons %}
+                    <a class="btn btn-success" href="{%url 'activity_signup' activity.id person.id %}">Tilmeld {{ person.firstname }} aktivitet</a>
+                  {% endfor %}
+                </td>
+                <td><a class="btn btn-primary" href="{%url 'activity_view_family' activity.id %}" target="_blank">Læs mere</a></td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      {% else %}
+        <div class="alert alert-primary">
+          Der er ikke nogen aktiviteter.
+        </div>
+      {% endif %}
 
       <h2>Ventelister</h2>
       <p>Tryk på <kbd>Opskriv</kbd> knapperne for hver afdeling der har interesse for jer. Bemærk at jeres position på ventelisten afgøres ud fra barnets oprettelses tidspunkt i systemet (datoen "Opskrevet" i Personer) - <i> ikke tidspunktet i melder jeg på ventelisterne nedenfor! - </i> I kan derfor frit tilmelde og framelde jer ventelisterne uden at frygte i mister jeres position på listen.</p>

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -119,9 +119,9 @@
               <table class="table table-striped table-responsive">
                 <thead>
                   <tr>
-                    <th class="col-3" align="left">Navn</th>
-                    <th class="col-6" align="left">Aktivitet</th>
-                    <th class="col-3 text-left" colspan="2">Reaktion</th>
+                    <th align="left">Navn</th>
+                    <th align="left">Aktivitet</th>
+                    <th class="text-left" colspan="2">Reaktion</th>
                   </tr>
                 </thead>
                 <tbody>

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -8,7 +8,7 @@
       <h2>Personer</h2>
       <p>Tryk på <kbd>Opret</kbd>-knapperne, for at tilføje flere personer. Opret gerne begge forældre, så vi kan få fat i jer nemt.</p>
         {% if family.person_set.count > 0 %}
-            <table class="table table-striped table-responsive" style="display: table; table-layout: fixed;">
+            <table class="table table-striped" style="display: table; table-layout: fixed;">
               <thead>
                 <tr>
                   <th class="col-1">Opskrevet</th>
@@ -70,7 +70,7 @@
       <h2>Tilmeldte aktiviteter</h2>
       <p>Dette er de aktiviteter jeres børn er tilmeldt. I kan klikke på navnet for hvert arrangement, for at se flere detaljer om hvor og hvornår det foregår. I kan også se deltagerlisten for arrangementet.</p>
       <p>Hvis et arrangement har en rød <kbd>betal</kbd>-knap, er betalingen ikke registreret. Tryk på knappen for at betale.</p>
-            <table class="table table-striped table-responsive">
+            <table class="table table-striped">
               <thead>
                 <tr>
                   <th class="col-sm-3">Navn</th>
@@ -100,7 +100,7 @@
       <h2>Invitationer / Åbne aktiviteter</h2>
       <p>Denne liste indeholder invitationer til aktiviteter, hvor der enten er fri tilmelding (først til mølle) eller invitationer til aktiviteter I har stået på venteliste til. I vil modtage en e-mail på e-mail-adressen {{family.email}} når der er aktiviteter, som I kan tilmelde jer.</p>
       {% if invites or waiting_lists or open_activities%}
-              <table class="table table-striped table-responsive">
+              <table class="table table-striped">
                 <thead>
                   <tr>
                     <th>Navn</th>
@@ -145,7 +145,7 @@
       <p>Opret jer kun på de lister der har interesse for jer. Det er en god ide at kigge forbi hyppigt op til sæsonstart, da vi tilføjer nye afdelinger efterhånden som vi får bekræftet de åbner og børnene får kun tilbud om at komme med på de afdelinger de har skrevet sig op til.</p>
       <h3><a href="{% url 'family_waitinglist_view' %}">Se jeres nuværende position på ventelisterne</a></h3>
         {% if department_children_waiting %}
-              <table class="table table-striped table-responsive">
+              <table class="table table-striped">
                 <thead>
                   <tr>
                     <th>Navn</th>

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -8,7 +8,7 @@
 
       <h2>Personer</h2>
       <p>Tryk på <kbd>Opret</kbd>-knapperne, for at tilføje flere personer. Opret gerne begge forældre, så vi kan få fat i jer nemt.</p>
-      <section class="card">
+      <div class="border">
         {% if family.person_set.count > 0 %}
           <table class="table table-striped table-responsive" style="display: table; table-layout: fixed;">
             <thead>
@@ -51,7 +51,7 @@
             </tbody>
           </table>
         {% endif %}
-      </section>
+        </div>
       <br>
       <a class="btn btn-primary" role="button" href="{% url 'person_add' 'CH' %}">Opret barn</a>
       <a class="btn btn-primary" role="button" href="{% url 'person_add' 'PA' %}">Opret forælder</a>
@@ -73,7 +73,6 @@
       <h2>Tilmeldte aktiviteter</h2>
       <p>Dette er de aktiviteter jeres børn er tilmeldt. I kan klikke på navnet for hvert arrangement, for at se flere detaljer om hvor og hvornår det foregår. I kan også se deltagerlisten for arrangementet.</p>
       <p>Hvis et arrangement har en rød <kbd>betal</kbd>-knap, er betalingen ikke registreret. Tryk på knappen for at betale.</p>
-      <section class="card">
         <table class="table table-striped table-responsive">
           <thead>
             <tr>
@@ -99,13 +98,11 @@
             {% endfor %}
           </tbody>
         </table>
-      </section>
       {% endif %}
 
       <h2>Invitationer / Åbne aktiviteter</h2>
       <p>Denne liste indeholder invitationer til aktiviteter, hvor der enten er fri tilmelding (først til mølle) eller invitationer til aktiviteter I har stået på venteliste til. I vil modtage en e-mail på e-mail-adressen {{family.email}} når der er aktiviteter, som I kan tilmelde jer.</p>
       {% if invites or waiting_lists or open_activities%}
-        <section class="card">
           <table class="table table-striped table-responsive">
             <thead>
               <tr>
@@ -139,7 +136,6 @@
 
               </tbody>
           </table>
-        </section>
       {% else %}
         <div class="alert alert-primary">
           Der er endnu ikke åbnet for tilmelding til aktiviteter. Vi sender en e-mail til {{family.email}} når vi er klar til at modtage tilmeldinger.
@@ -151,7 +147,6 @@
       <p>Tryk på <kbd>Afmeld</kbd> knapperne for at forlade en afdelings ventelisten igen.</p>
       <p>Opret jer kun på de lister der har interesse for jer. Det er en god ide at kigge forbi hyppigt op til sæsonstart, da vi tilføjer nye afdelinger efterhånden som vi får bekræftet de åbner og børnene får kun tilbud om at komme med på de afdelinger de har skrevet sig op til.</p>
       <h3><a href="{% url 'family_waitinglist_view' %}">Se jeres nuværende position på ventelisterne</a></h3>
-      <section class="card">
         {% if department_children_waiting %}
           <table class="table table-striped table-responsive">
             <thead>
@@ -194,7 +189,6 @@
               Der er ingen aktuelle ventelister.
             </div>
         {% endif %}
-      </section>
     </div>
   </div>
 {% endblock %}

--- a/members/templates/members/family_details.html
+++ b/members/templates/members/family_details.html
@@ -66,7 +66,7 @@
           </div>
           {%endif%}
 
-      {% if participating or waiting %}
+      {% if participating %}
       <h2>Tilmeldte aktiviteter</h2>
       <p>Dette er de aktiviteter jeres børn er tilmeldt. I kan klikke på navnet for hvert arrangement, for at se flere detaljer om hvor og hvornår det foregår. I kan også se deltagerlisten for arrangementet.</p>
       <p>Hvis et arrangement har en rød <kbd>betal</kbd>-knap, er betalingen ikke registreret. Tryk på knappen for at betale.</p>

--- a/members/templates/members/logout.html
+++ b/members/templates/members/logout.html
@@ -6,7 +6,7 @@
         Du er nu logget ud
     </div>
     <div class="alert alert-warning">
-        Husk at du vil modtage invitationer til aktiviteter og afdelinger du har skrevet dig op til fra <u>kontakt@codingpirates.dk</u>. Vær' derfor opmærksom på, at de ikke havner i spam, du kan evt. tilføje e-mailadressen til din kontaktbog.
+        Husk, at du vil modtage invitationer til aktiviteter og afdelinger du har skrevet dig op til fra <u>kontakt@codingpirates.dk</u>. Vær' derfor opmærksom på, at de ikke havner i spam, du kan evt. tilføje e-mailadressen til din kontaktbog.
     </div>
     <a class="btn btn-primary" href="{% url 'person_login' %}">Log ind</a>
 </div>

--- a/members/templates/members/logout.html
+++ b/members/templates/members/logout.html
@@ -1,7 +1,6 @@
 {% extends 'members/base.html' %}
 
 {% block content %}
-<div class="container">
     <div class="alert alert-primary">
         Du er nu logget ud
     </div>
@@ -9,5 +8,4 @@
         Husk, at du vil modtage invitationer til aktiviteter og afdelinger du har skrevet dig op til fra <u>kontakt@codingpirates.dk</u>. Vær' derfor opmærksom på, at de ikke havner i spam, du kan evt. tilføje e-mailadressen til din kontaktbog.
     </div>
     <a class="btn btn-primary" href="{% url 'person_login' %}">Log ind</a>
-</div>
 {% endblock %}

--- a/members/templates/members/logout.html
+++ b/members/templates/members/logout.html
@@ -1,0 +1,13 @@
+{% extends 'members/base.html' %}
+
+{% block content %}
+<div class="container">
+    <div class="alert alert-primary">
+        Du er nu logget ud
+    </div>
+    <div class="alert alert-warning">
+        Husk at du vil modtage invitationer til aktiviteter og afdelinger du har skrevet dig op til fra <u>kontakt@codingpirates.dk</u>. Vær' derfor opmærksom på, at de ikke havner i spam, du kan evt. tilføje e-mailadressen til din kontaktbog.
+    </div>
+    <a class="btn btn-primary" href="{% url 'person_login' %}">Log ind</a>
+</div>
+{% endblock %}

--- a/members/urls.py
+++ b/members/urls.py
@@ -63,9 +63,7 @@ urlpatterns = [
     ),
     url(
         r"^account/logout/$",
-        auth_views.LogoutView.as_view(
-            template_name="members/logout.html"
-        ),
+        auth_views.LogoutView.as_view(template_name="members/logout.html"),
         {"next_page": "/"},
         name="person_logout",
     ),

--- a/members/urls.py
+++ b/members/urls.py
@@ -63,7 +63,9 @@ urlpatterns = [
     ),
     url(
         r"^account/logout/$",
-        auth_views.LogoutView.as_view(),
+        auth_views.LogoutView.as_view(
+            template_name="members/logout.html"
+        ),
         {"next_page": "/"},
         name="person_logout",
     ),


### PR DESCRIPTION
Det ser måske voldsomt ud, men det er det ikke.
Tabs er reguleret
`row` og `col-12` sammen er fjernet
`align=left` fjernet (default)
Log ud-side er oprettet
`blockquote` er blevet til `alert`
`col` er fjernet ved nogle tabeller, hvor det ikke er nødvendigt. Nu kan de istedet automatisk resize

Løser #310 #259

Jeg håber den er ligetil