### PR TITLE
Removed border from bootstrap buttons

### DIFF
--- a/members/static/members/sass/buttons.css
+++ b/members/static/members/sass/buttons.css
@@ -11,9 +11,11 @@
 .btn-primary {
     color: white;
     background-color: #25a2ce;
+    border-color: #25a2ce;
 }
 
 .btn-primary:hover {
     color: white;
     background-color: #2c8098;
+    border-color: #2c8098;
 }


### PR DESCRIPTION
Fjerner standard border fra knapperne 

Sådan så de ud før
![Screenshot 2020-03-02 at 21 27 01](https://user-images.githubusercontent.com/3578071/75714871-c36ce980-5ccc-11ea-9abc-0937bf958949.png)


Sådan ser de ud nu 
![Screenshot 2020-03-02 at 21 27 46](https://user-images.githubusercontent.com/3578071/75714836-b64ffa80-5ccc-11ea-8df8-ef979a2e1a9f.png)
