### PR TITLE
Made codecov more lenient in CI

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,2 +1,8 @@
 ignore:
   - "members/tests" # wildcards accepted
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 2%  # the leniency in hitting the target


### PR DESCRIPTION
It's annoying to have red check due to minus `0.2` in coverage. 
Now it will only fail if coverage falls by 2%