### PR TITLE
Change UI label from 'mm-dd-åååå' -> 'dd-mm-åååå'

### DIFF
--- a/members/forms/person_form.py
+++ b/members/forms/person_form.py
@@ -142,7 +142,7 @@ class PersonForm(forms.ModelForm):
             "phone",
             "dawa_id",
         ]
-        labels = {"birthday": "Fødselsdato (mm-dd-åååå)"}
+        labels = {"birthday": "Fødselsdato (dd-mm-åååå)"}
         error_messages = {
             "birthday": {"invalid": "Indtast en gyldig dato. (dd-mm-åååå)"}
         }


### PR DESCRIPTION
Noticed by @mhewel

Previously the label when editing person birthday was incorrectly `mm-dd-åååå`, whereas the field is actually using `dd-mm-åååå`

<img width="430" alt="image" src="https://user-images.githubusercontent.com/11410667/168425090-0ce0e265-0e44-4a61-adcb-d37e74674f38.png">
