### PR TITLE
Add pgAdmin to Docker Compose

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,6 +31,11 @@ You are more than welcome to contribute to the system. This guide documents how 
 -   To create a super user for the admin interface you can run
     `docker-compose run web ./manage.py createsuperuser`
 
+-   A pgAdmin container is configured as part of Docker Compose, and can be accessed on http://localhost:5050.
+    Log in with credentials `admin@example.com`/`admin`. Connection to database has been configured in
+    `pgadmin/servers.json` file, you just need to provide password to database when asked (can be found
+    in your `.env` file)
+
 ## Primary Frameworks/Systems used
 
 -   [Django][django]: The base web framework used. The link is to their great

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,19 @@ services:
     ports:
       - "5432${DB_PORT}"
 
+  pgadmin:
+    image: dpage/pgadmin4
+    networks:
+      - webnet
+    restart: always
+    ports:
+      - "5050:80"
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@example.com
+      PGADMIN_DEFAULT_PASSWORD: admin
+    volumes:
+      - ${PWD}/pgadmin4/servers.json:/pgadmin4/servers.json
+
   selenium:
     image: selenium/standalone-chrome
     networks:

--- a/pgadmin4/servers.json
+++ b/pgadmin4/servers.json
@@ -1,0 +1,13 @@
+{
+    "Servers": {
+        "1": {
+            "Name": "forenings_medlemmer",
+            "Group": "Servers",
+            "Port": 5432,
+            "Username": "postgres_user",
+            "Host": "database",
+            "SSLMode": "prefer",
+            "MaintenanceDB": "postgres"
+        }
+    }
+}


### PR DESCRIPTION
When investigating the `'NoneType' object has no attribute 'family'` error, needed to have easy access to local database for testing.

So decided to add pgAdmin container to Docker Compose setup. After running `docker compose up`, it runs on http://localhost:5050, and gives a graphical interface to local Postgres database:

<img width="1225" alt="image" src="https://user-images.githubusercontent.com/11410667/188509440-375ac62c-c7e3-403c-bc45-f2a46bd9e3a2.png">

Hope others can find that useful :)