### PR TITLE
Handle authenticated user request without database user

### DIFF
--- a/members/views/EntryPage.py
+++ b/members/views/EntryPage.py
@@ -9,14 +9,19 @@ from members.utils.user import user_to_person
 @xframe_options_exempt
 def EntryPage(request):
     if not request.user.is_anonymous:
-        family = user_to_person(request.user).family
-        invites = ActivityInvite.objects.filter(
-            person__family=family, expire_dtm__gte=timezone.now(), rejected_dtm=None
-        )
+        user = user_to_person(request.user)
+        if user is None:
+            # e.g. if logged in as admin
+            context = {}
+        else:
+            family = user.family
+            invites = ActivityInvite.objects.filter(
+                person__family=family, expire_dtm__gte=timezone.now(), rejected_dtm=None
+            )
 
-        context = {
-            "invites": invites,
-        }
+            context = {
+                "invites": invites,
+            }
     else:
         context = {}
 


### PR DESCRIPTION
Fix for the `'NoneType' object has no attribute 'family'` error we have seen after https://github.com/CodingPirates/forenings_medlemmer/pull/436 was deployed couple of weeks ago

Was able to reproduce locally when signed in as admin and going to frontpage