### PR TITLE
Tilføjet verbose_name til modeller med foreignkey

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.linting.flake8Enabled": false
+}

--- a/members/models/activity.py
+++ b/members/models/activity.py
@@ -10,7 +10,7 @@ class Activity(models.Model):
         verbose_name_plural = "Aktiviteter"
         ordering = ["department__address__zipcode", "start_date"]
 
-    department = models.ForeignKey("Department", on_delete=models.CASCADE)
+    department = models.ForeignKey("Department", on_delete=models.CASCADE, verbose_name="Afdeling")
     union = models.ForeignKey("Union", blank=True, on_delete=models.CASCADE, default=1)
     name = models.CharField("Navn", max_length=200)
     activitytype = models.ForeignKey(

--- a/members/models/activity.py
+++ b/members/models/activity.py
@@ -10,7 +10,9 @@ class Activity(models.Model):
         verbose_name_plural = "Aktiviteter"
         ordering = ["department__address__zipcode", "start_date"]
 
-    department = models.ForeignKey("Department", on_delete=models.CASCADE, verbose_name="Afdeling")
+    department = models.ForeignKey(
+        "Department", on_delete=models.CASCADE, verbose_name="Afdeling"
+    )
     union = models.ForeignKey("Union", blank=True, on_delete=models.CASCADE, default=1)
     name = models.CharField("Navn", max_length=200)
     activitytype = models.ForeignKey(

--- a/members/models/activityinvite.py
+++ b/members/models/activityinvite.py
@@ -21,7 +21,9 @@ class ActivityInvite(models.Model):
         verbose_name_plural = "Invitationer"
         unique_together = ("activity", "person")
 
-    activity = models.ForeignKey("Activity", on_delete=models.CASCADE, verbose_name="Aktivitet")
+    activity = models.ForeignKey(
+        "Activity", on_delete=models.CASCADE, verbose_name="Aktivitet"
+    )
     person = models.ForeignKey("Person", on_delete=models.CASCADE)
     invite_dtm = models.DateField("Inviteret", default=timezone.now)
     expire_dtm = models.DateField("Udløber", default=_defaultInviteExpiretime)

--- a/members/models/activityinvite.py
+++ b/members/models/activityinvite.py
@@ -21,7 +21,7 @@ class ActivityInvite(models.Model):
         verbose_name_plural = "Invitationer"
         unique_together = ("activity", "person")
 
-    activity = models.ForeignKey("Activity", on_delete=models.CASCADE)
+    activity = models.ForeignKey("Activity", on_delete=models.CASCADE, verbose_name="Aktivitet")
     person = models.ForeignKey("Person", on_delete=models.CASCADE)
     invite_dtm = models.DateField("Inviteret", default=timezone.now)
     expire_dtm = models.DateField("Udløber", default=_defaultInviteExpiretime)

--- a/members/models/activityparticipant.py
+++ b/members/models/activityparticipant.py
@@ -14,8 +14,12 @@ class ActivityParticipant(models.Model):
         unique_together = ("activity", "member")
 
     added_dtm = models.DateField("Tilmeldt", default=timezone.now)
-    activity = models.ForeignKey("Activity", on_delete=models.PROTECT, verbose_name="Aktivitet")
-    member = models.ForeignKey("Member", on_delete=models.CASCADE, verbose_name="Medlem")
+    activity = models.ForeignKey(
+        "Activity", on_delete=models.PROTECT, verbose_name="Aktivitet"
+    )
+    member = models.ForeignKey(
+        "Member", on_delete=models.CASCADE, verbose_name="Medlem"
+    )
     note = models.TextField("Besked / Note til arrangement", blank=True)
     PHOTO_OK = "OK"
     PHOTO_NOTOK = "NO"

--- a/members/models/activityparticipant.py
+++ b/members/models/activityparticipant.py
@@ -14,8 +14,8 @@ class ActivityParticipant(models.Model):
         unique_together = ("activity", "member")
 
     added_dtm = models.DateField("Tilmeldt", default=timezone.now)
-    activity = models.ForeignKey("Activity", on_delete=models.PROTECT)
-    member = models.ForeignKey("Member", on_delete=models.CASCADE)
+    activity = models.ForeignKey("Activity", on_delete=models.PROTECT, verbose_name="Aktivitet")
+    member = models.ForeignKey("Member", on_delete=models.CASCADE, verbose_name="Medlem")
     note = models.TextField("Besked / Note til arrangement", blank=True)
     PHOTO_OK = "OK"
     PHOTO_NOTOK = "NO"

--- a/members/models/department.py
+++ b/members/models/department.py
@@ -19,9 +19,14 @@ class Department(models.Model):
     responsible_name = models.CharField("Afdelingsleder", max_length=200, blank=True)
     department_email = models.EmailField("E-mail", blank=True)
     department_leaders = models.ManyToManyField(
-        "Person", limit_choices_to={"user__is_staff": True}, blank=True, verbose_name="Afdelingsledere"
+        "Person",
+        limit_choices_to={"user__is_staff": True},
+        blank=True,
+        verbose_name="Afdelingsledere",
     )
-    address = models.ForeignKey("Address", on_delete=models.PROTECT,verbose_name="Adresse")
+    address = models.ForeignKey(
+        "Address", on_delete=models.PROTECT, verbose_name="Adresse"
+    )
     updated_dtm = models.DateTimeField("Opdateret", auto_now=True)
     created = models.DateField("Oprettet", blank=False, default=timezone.now)
     closed_dtm = models.DateField("Lukket", blank=True, null=True, default=None)

--- a/members/models/department.py
+++ b/members/models/department.py
@@ -19,9 +19,9 @@ class Department(models.Model):
     responsible_name = models.CharField("Afdelingsleder", max_length=200, blank=True)
     department_email = models.EmailField("E-mail", blank=True)
     department_leaders = models.ManyToManyField(
-        "Person", limit_choices_to={"user__is_staff": True}, blank=True
+        "Person", limit_choices_to={"user__is_staff": True}, blank=True, verbose_name="Afdelingsledere"
     )
-    address = models.ForeignKey("Address", on_delete=models.PROTECT)
+    address = models.ForeignKey("Address", on_delete=models.PROTECT,verbose_name="Adresse")
     updated_dtm = models.DateTimeField("Opdateret", auto_now=True)
     created = models.DateField("Oprettet", blank=False, default=timezone.now)
     closed_dtm = models.DateField("Lukket", blank=True, null=True, default=None)

--- a/members/models/member.py
+++ b/members/models/member.py
@@ -10,7 +10,9 @@ class Member(models.Model):
         verbose_name_plural = "Medlemmer"
         ordering = ["is_active", "member_since"]
 
-    department = models.ForeignKey("Department", on_delete=models.PROTECT,verbose_name="Afdeling")
+    department = models.ForeignKey(
+        "Department", on_delete=models.PROTECT, verbose_name="Afdeling"
+    )
     person = models.OneToOneField("Person", on_delete=models.PROTECT)
     is_active = models.BooleanField("Aktiv", default=True)
     member_since = models.DateField("Indmeldt", blank=False, default=timezone.now)

--- a/members/models/member.py
+++ b/members/models/member.py
@@ -10,7 +10,7 @@ class Member(models.Model):
         verbose_name_plural = "Medlemmer"
         ordering = ["is_active", "member_since"]
 
-    department = models.ForeignKey("Department", on_delete=models.PROTECT)
+    department = models.ForeignKey("Department", on_delete=models.PROTECT,verbose_name="Afdeling")
     person = models.OneToOneField("Person", on_delete=models.PROTECT)
     is_active = models.BooleanField("Aktiv", default=True)
     member_since = models.DateField("Indmeldt", blank=False, default=timezone.now)

--- a/members/models/union.py
+++ b/members/models/union.py
@@ -48,15 +48,19 @@ class Union(models.Model):
         null=True,
         blank=True,
         related_name="secretary",
-        verbose_name="Sekretær"
+        verbose_name="Sekretær",
     )
     secretary_old = models.CharField("Sekretær", max_length=200, blank=True)
     secretary_email_old = models.EmailField("Sekretærens email", blank=True)
     union_email = models.EmailField("Foreningens email", blank=True)
     statues = models.URLField("Link til gældende vedtægter", blank=True)
     founded = models.DateField("Stiftet", blank=True, null=True)
-    address = models.ForeignKey("Address", on_delete=models.PROTECT, verbose_name="Adresse")
-    board_members = models.ManyToManyField("Person", blank=True, verbose_name="Menige medlemmer")
+    address = models.ForeignKey(
+        "Address", on_delete=models.PROTECT, verbose_name="Adresse"
+    )
+    board_members = models.ManyToManyField(
+        "Person", blank=True, verbose_name="Menige medlemmer"
+    )
     board_members_old = models.TextField("Menige medlemmer", blank=True)
     bank_main_org = models.BooleanField(
         "Sæt kryds hvis I har konto hos hovedforeningen (og ikke har egen bankkonto).",

--- a/members/models/union.py
+++ b/members/models/union.py
@@ -18,6 +18,7 @@ class Union(models.Model):
         related_name="chairman",
         null=True,
         blank=True,
+        verbose_name="Formand",
     )
     chairman_old = models.CharField("Formand", max_length=200, blank=True)
     chairman_email_old = models.EmailField("Formandens email", blank=True)
@@ -27,6 +28,7 @@ class Union(models.Model):
         null=True,
         blank=True,
         related_name="second_chair",
+        verbose_name="Næstformand",
     )
     second_chair_old = models.CharField("Næstformand", max_length=200, blank=True)
     second_chair_email_old = models.EmailField("Næstformandens email", blank=True)
@@ -36,6 +38,7 @@ class Union(models.Model):
         related_name="cashier",
         null=True,
         blank=True,
+        verbose_name="Kasserer",
     )
     cashier_old = models.CharField("Kasserer", max_length=200, blank=True)
     cashier_email_old = models.EmailField("Kassererens email", blank=True)
@@ -45,14 +48,15 @@ class Union(models.Model):
         null=True,
         blank=True,
         related_name="secretary",
+        verbose_name="Sekretær"
     )
     secretary_old = models.CharField("Sekretær", max_length=200, blank=True)
     secretary_email_old = models.EmailField("Sekretærens email", blank=True)
     union_email = models.EmailField("Foreningens email", blank=True)
     statues = models.URLField("Link til gældende vedtægter", blank=True)
     founded = models.DateField("Stiftet", blank=True, null=True)
-    address = models.ForeignKey("Address", on_delete=models.PROTECT)
-    board_members = models.ManyToManyField("Person", blank=True)
+    address = models.ForeignKey("Address", on_delete=models.PROTECT, verbose_name="Adresse")
+    board_members = models.ManyToManyField("Person", blank=True, verbose_name="Menige medlemmer")
     board_members_old = models.TextField("Menige medlemmer", blank=True)
     bank_main_org = models.BooleanField(
         "Sæt kryds hvis I har konto hos hovedforeningen (og ikke har egen bankkonto).",

--- a/members/models/volunteer.py
+++ b/members/models/volunteer.py
@@ -10,7 +10,7 @@ class Volunteer(models.Model):
         verbose_name_plural = "Frivillige"
 
     person = models.ForeignKey("Person", on_delete=models.CASCADE)
-    department = models.ForeignKey("Department", on_delete=models.CASCADE)
+    department = models.ForeignKey("Department", on_delete=models.CASCADE, verbose_name="Afdeling")
 
     def has_certificate(self):
         return self.person.has_certificate

--- a/members/models/volunteer.py
+++ b/members/models/volunteer.py
@@ -10,7 +10,9 @@ class Volunteer(models.Model):
         verbose_name_plural = "Frivillige"
 
     person = models.ForeignKey("Person", on_delete=models.CASCADE)
-    department = models.ForeignKey("Department", on_delete=models.CASCADE, verbose_name="Afdeling")
+    department = models.ForeignKey(
+        "Department", on_delete=models.CASCADE, verbose_name="Afdeling"
+    )
 
     def has_certificate(self):
         return self.person.has_certificate

--- a/members/models/waitinglist.py
+++ b/members/models/waitinglist.py
@@ -11,7 +11,7 @@ class WaitingList(models.Model):
         ordering = ["on_waiting_list_since"]
 
     person = models.ForeignKey("Person", on_delete=models.CASCADE)
-    department = models.ForeignKey("Department", on_delete=models.CASCADE)
+    department = models.ForeignKey("Department", on_delete=models.CASCADE, verbose_name="Afdeling")
     on_waiting_list_since = models.DateTimeField(
         "Venteliste position", blank=False, null=False
     )

--- a/members/models/waitinglist.py
+++ b/members/models/waitinglist.py
@@ -11,7 +11,9 @@ class WaitingList(models.Model):
         ordering = ["on_waiting_list_since"]
 
     person = models.ForeignKey("Person", on_delete=models.CASCADE)
-    department = models.ForeignKey("Department", on_delete=models.CASCADE, verbose_name="Afdeling")
+    department = models.ForeignKey(
+        "Department", on_delete=models.CASCADE, verbose_name="Afdeling"
+    )
     on_waiting_list_since = models.DateTimeField(
         "Venteliste position", blank=False, null=False
     )


### PR DESCRIPTION
Gennemgået de fleste modeller i venstremenuen under admin, så navngivningen er på dansk og mere ensartet.