### PR TITLE
Upgrade to Node.js 14.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM python:3.10
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y \
+RUN curl -fsSL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get update && apt-get install -y \
     graphviz \
-    nodejs \
-    npm
+    nodejs
 
 RUN npm install -g npm
 


### PR DESCRIPTION
We experienced build errors like
```
Step 4/21 : RUN npm install -g npm
 ---> Running in a67f4bf03f35
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'npm@9.1.2',
npm WARN EBADENGINE   required: { node: '^14.17.0 || ^16.13.0 || >=18.0.0' },
npm WARN EBADENGINE   current: { node: 'v12.22.12', npm: '7.5.2' }
npm WARN EBADENGINE }
```

According to https://stackoverflow.com/a/34594609 / https://github.com/nodesource/distributions/blob/master/README.md#debinstall special command is required for installing newer node.js versions on Debian