### PR TITLE
Feature/#761. Beskrivelse af handling for CSV Export i Admin > Deltagere

### DIFF
--- a/members/admin/__init__.py
+++ b/members/admin/__init__.py
@@ -603,7 +603,7 @@ class ActivityParticipantAdmin(admin.ModelAdmin):
         response["Content-Disposition"] = 'attachment; filename="deltagere.csv"'
         return response
 
-    export_csv_full2.short_description = "CSV Export (Forening; Afdeling; Aktivitet; Navn; Alder; Køn; Post-nr; Betalingsinfo; forældre-navn; forældre-email; forældre-telefon; Note-til-arrangørerne)"
+    export_csv_full2.short_description = "CSV Export"
 
 
 admin.site.register(ActivityParticipant, ActivityParticipantAdmin)


### PR DESCRIPTION
Beskrivelse af handling for CSV Export i Admin > Deltagere er rettet til at være uden alle felter angivet i parantes