### PR TITLE
Kør 'black' hver gang vi laver noget, så det er nemmere at læse koden

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,7 +47,10 @@ You are more than welcome to contribute to the system. This guide documents how 
     ```bash
     chmod +x .git/hooks/pre-commit
     ```
-    Note: This only works on Unix. (MacOS or Linux)
+    Note: This only works on Unix. (MacOS or Linux) And only if you have black installed on python3 with
+    ```bash
+    python3 -m pip install black
+    ```
 
 > **_NOTE:_** If using linux with SELINUX you may need to add/change the following to your docker-compose.yml
 >

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -38,6 +38,17 @@ You are more than welcome to contribute to the system. This guide documents how 
     `pgadmin/servers.json` file, you just need to provide password to database when asked (can be found
     in your `.env` file)
 
+- To enable auto formatting with black on Linux: 
+    copy the pre-commit file into the .git/hooks directory
+    ```bash
+    cp pre-commit .git/hooks
+    ```
+    and then give it executeable permissions
+    ```bash
+    chmod +x .git/hooks/pre-commit
+    ```
+    Note: This only works on Unix. (MacOS or Linux)
+
 > **_NOTE:_** If using linux with SELINUX you may need to add/change the following to your docker-compose.yml
 >
 > ``` yml

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/bash
+echo "Formatting with black..."
+python3 -m black .


### PR DESCRIPTION
Since .git is ignored by git by default you have to move the pre-commit file to .git/hooks to enable it. Added tutorial to enable auto formatting in contributing.md