### PR TITLE
Fjern reference til codecov pakke

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ authors = ["Kristoffer Rath Hansen <kristoffer@codingpirates.dk>"]
 [tool.poetry.dependencies]
 python = "^3.10.0"
 black = "^22.3"
-codecov = "2.1.12"
 dj-database-url = "0.5.0"
 dj-email-url = "1.0.6"
 django = "^4.1"


### PR DESCRIPTION
Se f.eks. https://github.com/CodingPirates/forenings_medlemmer/actions/runs/4772419383/jobs/8485607295?pr=872 som fejler med
```
Unable to find installation candidates for codecov (2.1.12)
```
Ifølge https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259 er denne pakke ikke længere tilgængelig, og vi kan bare fjerne referencen