### PR TITLE
Opdater codecov til 2.1.13

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -236,14 +236,14 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "codecov"
-version = "2.1.12"
+version = "2.1.13"
 description = "Hosted coverage reports for GitHub, Bitbucket and Gitlab"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 files = [
-    {file = "codecov-2.1.12-py2.py3-none-any.whl", hash = "sha256:585dc217dc3d8185198ceb402f85d5cb5dbfa0c5f350a5abcdf9e347776a5b47"},
-    {file = "codecov-2.1.12.tar.gz", hash = "sha256:a0da46bb5025426da895af90938def8ee12d37fcbcbbbc15b6dc64cf7ebc51c1"},
+    {file = "codecov-2.1.13-py2.py3-none-any.whl", hash = "sha256:c2ca5e51bba9ebb43644c43d0690148a55086f7f5e6fd36170858fa4206744d5"},
+    {file = "codecov-2.1.13.tar.gz", hash = "sha256:2362b685633caeaf45b9951a9b76ce359cd3581dd515b430c6c3f5dfb4d92a8c"},
 ]
 
 [package.dependencies]
@@ -1248,4 +1248,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10.0"
-content-hash = "6904663c25c31379b6ca729655f8b326b34b1c480d0a407f3a99f950e7f24518"
+content-hash = "804e3ad7fbfa7d766eee5e8a5ef784a85c04e6083d21fa3b6f99cc6b8b4ce89c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = ["Kristoffer Rath Hansen <kristoffer@codingpirates.dk>"]
 [tool.poetry.dependencies]
 python = "^3.10.0"
 black = "^22.3"
-codecov = "2.1.12"
+codecov = "2.1.13"
 dj-database-url = "0.5.0"
 dj-email-url = "1.0.6"
 django = "^4.1"


### PR DESCRIPTION
Se f.eks. https://github.com/CodingPirates/forenings_medlemmer/actions/runs/4772419383/jobs/8485607295?pr=872 som fejler med
```
Unable to find installation candidates for codecov (2.1.12)
```
Ifølge https://about.codecov.io/blog/message-regarding-the-pypi-package/ er der ny 2.1.13 pakke tilgængelig nu