### PR TITLE
Alle Ventelister: Mailto-link indeholder ikke mail addresse

### DIFF
--- a/members/templates/members/department_signup.html
+++ b/members/templates/members/department_signup.html
@@ -91,7 +91,7 @@
                   </td>
                   <td>
                     {{ department.responsible_name }} <br>
-                    <a href="mailto:{{ department.object.department_email }}">
+                    <a href="mailto:{{ department.department_email }}">
                       {{ department.department_email }}
                     </a>
                   </td>


### PR DESCRIPTION
Er på https://members.codingpirates.dk/department_signup, hvor nuværende mailto link er tomt