### PR TITLE
Vis kun relevante afdelinger i dropdown på deltager admin side

### DIFF
--- a/members/admin/activityparticipant_admin.py
+++ b/members/admin/activityparticipant_admin.py
@@ -9,7 +9,6 @@ from django.utils.safestring import mark_safe
 from members.models import (
     Activity,
     AdminUserInformation,
-    Department,
     Union,
 )
 
@@ -23,7 +22,9 @@ class ActivityParticipantDepartmentFilter(admin.SimpleListFilter):
     def lookups(self, request, model_admin):
         return [
             (str(department.pk), str(department))
-            for department in Department.objects.all().order_by("name")
+            for department in AdminUserInformation.get_departments_admin(
+                request.user
+            ).order_by("name")
         ]
 
     def queryset(self, request, queryset):


### PR DESCRIPTION
Tidligere viste `Afdelinger` dropdown på https://members.codingpirates.dk/admin/members/activityparticipant/ alle afdelinger:
<img width="360" alt="image" src="https://github.com/nallic/forenings_medlemmer/assets/3763552/9527ae53-2b5e-48fa-ae95-c524b8da4854">

Med denne rettelse vises kun relevante afdelinger. Dette er samme kode som brugt i f.eks. https://github.com/CodingPirates/forenings_medlemmer/blob/master/members/admin/waitinglist_admin.py