### PR TITLE
Når man har tilmeldt sig aktivitet skal man ikke sendes tilbage til venteliste opskrivning

### DIFF
--- a/members/static/members/js/tab.js
+++ b/members/static/members/js/tab.js
@@ -13,7 +13,8 @@ document.addEventListener("DOMContentLoaded", function(event) {
     const urlFragment = window.location.hash.substring(1); // Remove the '#' char
 
     // Default to the first list item as active if the ID is not provided or doesn't match any item
-    const activeIndex = tabButtons.findIndex(button => button.id === urlFragment);
+    // we use custom attribute data-navigation to set the "navigation url" for tab
+    const activeIndex = tabButtons.findIndex(button => button.dataset.navigation === urlFragment);
     const defaultIndex = activeIndex !== -1 ? activeIndex : 0;
 
     // Default to first as active
@@ -38,6 +39,9 @@ function toggleActive(sections, buttons, activeIndex) {
   sections[activeIndex].hidden = false;
 
   // set url to include the tab identifier. we overwrite url, since tabs doesn't work otherwise
-  const newUrl = window.location.pathname + `#${buttons[activeIndex].id}`;
-  window.history.replaceState({}, "", newUrl);
+  // we use custom attribute data-navigation to set the url for tab
+  if (buttons[activeIndex].dataset.navigation) {
+    const newUrl = window.location.pathname + `#${buttons[activeIndex].dataset.navigation}`;
+    window.history.replaceState({}, "", newUrl);
+  }
 }

--- a/members/static/members/js/tab.js
+++ b/members/static/members/js/tab.js
@@ -9,13 +9,23 @@ document.addEventListener("DOMContentLoaded", function(event) {
       Array.from(tabs.children).filter(element => element.tagName === "SECTION")
     );
 
+    // Get the 'active' parameter value from the URL fragment
+    const urlFragment = window.location.hash.substr(1); // Remove the '#' symbol
+    const activeItemId = urlFragment.split("=")[1];
+    
+    // Default to the first list item as active if the ID is not provided or doesn't match any item
+    const activeIndex = tabButtons.findIndex(button => button.id === activeItemId);
+    const defaultIndex = activeIndex !== -1 ? activeIndex : 0;
+    
     // Default to first as active
-    toggleActive(sections, tabButtons, 0);
+    toggleActive(sections, tabButtons, defaultIndex);
 
     for (var button of tabButtons) {
       button.addEventListener("click", event =>
         toggleActive(sections, tabButtons, tabButtons.indexOf(event.srcElement))
       );
+      const newUrl = window.location.pathname; // Remove any query parameters or hash from the URL
+      window.history.pushState({}, "", newUrl);
     }
   }
 });

--- a/members/static/members/js/tab.js
+++ b/members/static/members/js/tab.js
@@ -9,23 +9,20 @@ document.addEventListener("DOMContentLoaded", function(event) {
       Array.from(tabs.children).filter(element => element.tagName === "SECTION")
     );
 
-    // Get the 'active' parameter value from the URL fragment
-    const urlFragment = window.location.hash.substr(1); // Remove the '#' symbol
-    const activeItemId = urlFragment.split("=")[1];
-    
+    // Get the 'active tab' parameter value from the URL fragment (after #-character)
+    const urlFragment = window.location.hash.substring(1); // Remove the '#' char
+
     // Default to the first list item as active if the ID is not provided or doesn't match any item
-    const activeIndex = tabButtons.findIndex(button => button.id === activeItemId);
+    const activeIndex = tabButtons.findIndex(button => button.id === urlFragment);
     const defaultIndex = activeIndex !== -1 ? activeIndex : 0;
-    
+
     // Default to first as active
     toggleActive(sections, tabButtons, defaultIndex);
 
     for (var button of tabButtons) {
       button.addEventListener("click", event =>
-        toggleActive(sections, tabButtons, tabButtons.indexOf(event.srcElement))
+        toggleActive(sections, tabButtons, tabButtons.indexOf(event.target))
       );
-      const newUrl = window.location.pathname; // Remove any query parameters or hash from the URL
-      window.history.pushState({}, "", newUrl);
     }
   }
 });
@@ -39,4 +36,8 @@ function toggleActive(sections, buttons, activeIndex) {
   }
   buttons[activeIndex].classList.add("tab-active");
   sections[activeIndex].hidden = false;
+
+  // set url to include the tab identifier. we overwrite url, since tabs doesn't work otherwise
+  const newUrl = window.location.pathname + `#${buttons[activeIndex].id}`;
+  window.history.replaceState({}, "", newUrl);
 }

--- a/members/templates/members/activities.html
+++ b/members/templates/members/activities.html
@@ -15,11 +15,11 @@
   <div class="tabs" id="tab-menu">
     <ul>
       {% if family %}
-        <li id="tab-invitationer">Invitationer</li>
+        <li id="tab-invitationer" data-navigation="invitationer">Invitationer</li>
       {% endif %}
-      <li id="tab-aktiviteter">Nuværende og kommende aktiviteter</li>
+      <li id="tab-aktiviteter" data-navigation="aktiviteter">Nuværende og kommende aktiviteter</li>
       {% if family %}
-        <li id="tab-tilmeldte-aktiviteter">Tilmeldte aktiviteter</li>
+        <li id="tab-tilmeldte-aktiviteter" data-navigation="tilmeldte-aktiviteter">Tilmeldte aktiviteter</li>
       {% endif %}
       </ul>
 

--- a/members/views/ActivitySignup.py
+++ b/members/views/ActivitySignup.py
@@ -148,7 +148,7 @@ def ActivitySignup(request, activity_id, person_id=None):
             participant.save()
 
             # return user to list of activities where they are participating
-            return_link_url = f'{reverse("activities")}#tab-tilmeldte-aktiviteter'
+            return_link_url = f'{reverse("activities")}#tilmeldte-aktiviteter'
 
             # Make payment if activity costs
             if activity.price_in_dkk is not None and activity.price_in_dkk > 0:

--- a/members/views/ActivitySignup.py
+++ b/members/views/ActivitySignup.py
@@ -147,9 +147,8 @@ def ActivitySignup(request, activity_id, person_id=None):
             participant.photo_permission = signup_form.cleaned_data["photo_permission"]
             participant.save()
 
-            return_link_url = reverse(
-                "activity_view_person", args=[activity.id, person.id]
-            )
+            # return user to list of activities where they are participating
+            return_link_url = f'{reverse("activities")}#tab-tilmeldte-aktiviteter'
 
             # Make payment if activity costs
             if activity.price_in_dkk is not None and activity.price_in_dkk > 0:
@@ -171,8 +170,7 @@ def ActivitySignup(request, activity_id, person_id=None):
                     payment.save()
 
                     return_link_url = payment.get_quickpaytransaction().get_link_url(
-                        return_url=settings.BASE_URL
-                        + reverse("activity_view_person", args=[activity.id, person.id])
+                        return_url=settings.BASE_URL + return_link_url
                     )
 
             # expire invitation


### PR DESCRIPTION
Se #846 

Når man har tilmeldt sig aktivitet bliver man ledt videre til oversigt over tilmeldte aktiviteter, da der ellers lader til at være tendens til at forældre skriver sig på venteliste igen.

Dette inkluderer:
* Support for `#` i url til at vælge aktive faneblad/tab, testet lokalt med f.eks. http://localhost:8000/activities/#tab-tilmeldte-aktiviteter - se screendump
* Når man har tilmeldt sig en aktivitet, bliver brugeren viderestillet til `/activities/#tab-tilmeldte-aktiviteter`

<img width="1282" alt="image" src="https://github.com/CodingPirates/forenings_medlemmer/assets/3763552/93870752-1693-4a67-8579-0c41cfd42676">
