### PR TITLE
Opdatering til #963: Brug exists() i stedet for count()

### DIFF
--- a/members/admin/activityinvite_admin.py
+++ b/members/admin/activityinvite_admin.py
@@ -247,10 +247,9 @@ class ActivityInviteAdmin(admin.ModelAdmin):
     person_link.admin_order_field = "person__name"
 
     def participating(self, item):
-        return (
-            item.person.activityparticipant_set.filter(activity=item.activity).count()
-            > 0
-        )
+        return item.person.activityparticipant_set.filter(
+            activity=item.activity
+        ).exists()
 
     participating.short_description = "Deltager"
     participating.boolean = True


### PR DESCRIPTION
Efter review fra @lakridserne på #963 (vis checkmark på invitation, om person allerede er tilmeldt aktivitet), ændret `count() > 0` til `exists()`