### PR TITLE
Redirect bruger efter login

### DIFF
--- a/members/templates/members/activities.html
+++ b/members/templates/members/activities.html
@@ -239,14 +239,14 @@
                           {% if activity.open_invite %}
                             <a
                               class="button-success"
-                              href="{% url 'person_login' %}"
+                              href="{% url 'person_login' %}?next={{request.path}}"
                             >
                               Tilmeld
                             </a>
                           {% else %}
                             <a
                               class="button-success"
-                              href="{% url 'person_login' %}"
+                              href="{% url 'person_login' %}?next={{request.path}}"
                             >
                               Opskriv på venteliste
                             </a>

--- a/members/templates/members/activity_signup.html
+++ b/members/templates/members/activity_signup.html
@@ -88,8 +88,8 @@
       {% else %}
         {% if not family %}
           <hr>
-          <a href="{% url 'person_login' %}">Log ind</a>
-          eller 
+          <a href="{% url 'person_login' %}?next={{request.path}}">Log ind</a>
+          eller
           <a href="{% url 'account_create' %}">tilmeld dit barn</a>
           for at tilmelde dig denne aktivitet.
         {% else %}

--- a/members/templates/members/header.html
+++ b/members/templates/members/header.html
@@ -18,7 +18,7 @@
     {% else %}
         <a href="{% url "account_create" %}">Tilmeld barn</a>
         <a href="{% url "volunteer_signup" %}">Bliv frivillig</a>
-        <a id="login-logout" href="{% url 'person_login' %}">Log ind</a>
+        <a id="login-logout" href="{% url 'person_login' %}?next={{request.path}}">Log ind</a>
     {% endif %}
     <a href="https://codingpirates.dk" target="_blank">
         <img src="{% static "logo.png" %}"/>


### PR DESCRIPTION
Se https://github.com/CodingPirates/forenings_medlemmer/issues/762

Brug `next` query string parameter til at redirect'e brugeren tilbage til f.eks. aktivitetsside efter login. Brugen af `next` er dokumenteret på f.eks. https://docs.djangoproject.com/en/4.2/topics/auth/default/#the-login-required-decorator:

> will use the value of `redirect_field_name` as its key rather than "next" (the default).