### PR TITLE
Flyt links til Piratnyt og Facebook til forsiden, fra user-signup side

### DIFF
--- a/members/templates/members/entry_page.html
+++ b/members/templates/members/entry_page.html
@@ -47,6 +47,22 @@
         <p>Donér til Coding Pirates som støttemedlem</p>
       </div>
     </div>
+    <div>
+      <span><i class="fa-link fa fa-4x"></i></span>
+      <div>
+        <h4>Links</h4>
+        <p>
+          Nyhedsbrev og andre nyttige grupper
+        </p>
+        <a href="https://codingpirates.dk/tilmeld-dig-til-piratnyt/" target=”_blank”>
+          PiratNyt <i class="fa fa-long-arrow-alt-right"></i>
+        </a>
+        <p></p>
+        <a href="https://www.facebook.com/groups/codingpiratescommunity" target=”_blank”>
+          Facebook <i class="fa fa-long-arrow-alt-right"></i>
+        </a>
+      </div>
+    </div>
   </div>
 
   <p class="text-center">

--- a/members/templates/members/user_created.html
+++ b/members/templates/members/user_created.html
@@ -7,26 +7,6 @@
         <p>Vi har oprettet en bruger til dig. Du logger ind ved hjælp af din e-mail-adresse samt adgangskode.</p>
         <p>Hvis du har glemt din adgangskode kan du få den tilbage med <a href="/account/forgot/">Password nulstilling</a></p>
         <hr />
-        <p>Herunder kan du finde og tilmelde dig vores forskellige communities og kommunikations kanaler, så du kan holde dig godt opdateret:</p>
-
-        <div>
-          <h4>Piratnyt - Nyhedsbrev</h4>
-          <p>PiratNyt er vores månedlige interne nyhedsbrev til alle frivillige i organisationen.</p>
-          <p>Her skriver vi om ting, der er relevante for dig som frivillig samt generelle opdateringer om Coding Pirates. Du vil bl.a. modtage nyt fra Hovedbestyrelsen, inspiration til klubaftenerne, gode råd samt nyheder fra måneden, der er gået.</p>
-          <p>
-            <a href="https://codingpirates.dk/tilmeld-dig-til-piratnyt/" target=”_blank”>Tilmeld dig til PiratNyt her (åbner nyt faneblad)</a>
-          </p>
-        </div>
-
-        <div>
-          <h4>Coding Pirates Facebook</h4>
-          <p>Facebook bruges til at dele idéer og erfaringer blandt frivillige på tværs af afdelinger i hele landet.</p>
-          <p>
-            <a href="https://www.facebook.com/groups/codingpiratescommunity" target=”_blank”>Find Coding Pirates Community gruppen her (åbner nyt faneblad)</a>
-          </p>
-        </div>
-
-        <hr />
         <a class="btn btn-primary" href="{% url 'person_login' %}">Gå til log ind →</a>
       </div>
 {% endblock %}


### PR DESCRIPTION
Del af [#969 [Feature] Redirect bruger til seneste side, ved brugeroprettelse og flyt information om Piratnyt osv til forsiden](https://github.com/CodingPirates/forenings_medlemmer/issues/969)

Denne boks med links til Piratnyt tilmelding og Facebook er tilføjet forsiden fra siden når man har oprettet sig som bruger (hvor man typisk er i gang med at tilmelde til en aktivitet, så man tænker ikke lige over Piratnyt osv)
<img width="1196" alt="image" src="https://github.com/CodingPirates/forenings_medlemmer/assets/3763552/429a9ac9-ef57-4410-b57b-8312792c33f7">
