### PR TITLE
Vis links til frivilligportal guide fra admin UI

### DIFF
--- a/members/templates/admin/base_site.html
+++ b/members/templates/admin/base_site.html
@@ -2,6 +2,7 @@
 
 {% block usertools %}
     <div id="user-tools">
+        {# TODO: Update link if/when we're moving away from frivillig.codingpirates.dk site #}
         <a href="https://frivillig.codingpirates.dk/medlemssystemet/guides/" target="_blank" style="font-weight: bold;">Admin guide til brug af medlemssystem</a>
     </div>
     {{ block.super }}

--- a/members/templates/admin/base_site.html
+++ b/members/templates/admin/base_site.html
@@ -1,0 +1,8 @@
+{% extends "admin/base_site.html" %}
+
+{% block usertools %}
+    <div id="user-tools">
+        <a href="https://frivillig.codingpirates.dk/medlemssystemet/guides/" target="_blank" style="font-weight: bold;">Admin guide til brug af medlemssystem</a>
+    </div>
+    {{ block.super }}
+{% endblock %}


### PR DESCRIPTION
Relateret til https://codingpirates.slack.com/archives/C2NCFUE30/p1704803609722099, hvor vi skulle sende link til admin guide i Slack. Hvis denne havde været tilgængelig fra admin UI, havde brugeren måske nemmere kunne have fundet informationen selv.

Implementeret ifølge https://docs.djangoproject.com/en/3.2/howto/overriding-templates/#extending-an-overridden-template

**Desktop eksempel:**
![image](https://github.com/CodingPirates/forenings_medlemmer/assets/3763552/4dba76fe-5e30-4435-b6e5-fcd8d63583e5)

**Mobil:**
![image](https://github.com/CodingPirates/forenings_medlemmer/assets/3763552/a912054b-d401-4af9-92e2-a7e06497872a)
