### PR TITLE
[#880] Escape admin felter, så evt. HTML koder ikke renderes

### DIFF
--- a/members/admin/activity_admin.py
+++ b/members/admin/activity_admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.utils.html import escape
 
 from members.models import (
     ActivityParticipant,
@@ -133,7 +134,7 @@ class ActivityAdmin(admin.ModelAdmin):
 
     def union_link(self, item):
         url = reverse("admin:members_union_change", args=[item.department.union_id])
-        link = '<a href="%s">%s</a>' % (url, item.department.union.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.department.union.name))
         return mark_safe(link)
 
     union_link.short_description = "Forening"
@@ -141,7 +142,7 @@ class ActivityAdmin(admin.ModelAdmin):
 
     def department_link(self, item):
         url = reverse("admin:members_department_change", args=[item.department_id])
-        link = '<a href="%s">%s</a>' % (url, item.department.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.department.name))
         return mark_safe(link)
 
     department_link.short_description = "Afdeling"
@@ -166,7 +167,7 @@ class ActivityAdmin(admin.ModelAdmin):
     def activity_membership_union_link(self, obj):
         if obj.activitytype_id in ["FORENINGSMEDLEMSKAB", "STØTTEMEDLEMSKAB"]:
             url = reverse("admin:members_union_change", args=[obj.union_id])
-            link = '<a href="%s">%s</a>' % (url, obj.union.name)
+            link = '<a href="%s">%s</a>' % (url, escape(obj.union.name))
             return mark_safe(link)
         else:
             return ""

--- a/members/admin/activityinvite_admin.py
+++ b/members/admin/activityinvite_admin.py
@@ -232,7 +232,7 @@ class ActivityInviteAdmin(admin.ModelAdmin):
 
     def activity_link(self, item):
         url = reverse("admin:members_activity_change", args=[item.activity.id])
-        link = '<a href="%s">%s</a>' % (url, item.activity.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.activity.name))
         return mark_safe(link)
 
     activity_link.short_description = "Aktivitet"

--- a/members/admin/activityparticipant_admin.py
+++ b/members/admin/activityparticipant_admin.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.safestring import mark_safe
+from django.utils.html import escape
 
 from members.models import (
     Activity,
@@ -254,7 +255,7 @@ class ActivityParticipantAdmin(admin.ModelAdmin):
 
     def activity_person_link(self, item):
         url = reverse("admin:members_person_change", args=[item.person_id])
-        link = '<a href="%s">%s</a>' % (url, item.person.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.person.name))
         return mark_safe(link)
 
     activity_person_link.short_description = "Deltager"
@@ -262,7 +263,7 @@ class ActivityParticipantAdmin(admin.ModelAdmin):
 
     def activity_family_email_link(self, item):
         url = reverse("admin:members_family_change", args=[item.person.family_id])
-        link = '<a href="%s">%s</a>' % (url, item.person.family.email)
+        link = '<a href="%s">%s</a>' % (url, escape(item.person.family.email))
         return mark_safe(link)
 
     activity_family_email_link.short_description = "Familie"
@@ -270,7 +271,7 @@ class ActivityParticipantAdmin(admin.ModelAdmin):
 
     def activity_link(self, item):
         url = reverse("admin:members_activity_change", args=[item.activity.id])
-        link = '<a href="%s">%s</a>' % (url, item.activity.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.activity.name))
         return mark_safe(link)
 
     activity_link.short_description = "Aktivitet"
@@ -280,7 +281,7 @@ class ActivityParticipantAdmin(admin.ModelAdmin):
         url = reverse(
             "admin:members_department_change", args=[item.activity.department_id]
         )
-        link = '<a href="%s">%s</a>' % (url, item.activity.department.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.activity.department.name))
         return mark_safe(link)
 
     activity_department_link.short_description = "Afdeling"

--- a/members/admin/department_admin.py
+++ b/members/admin/department_admin.py
@@ -3,6 +3,7 @@ from django.db.models.functions import Upper
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from members.models import Union, Address, Person
+from django.utils.html import escape
 
 
 class UnionDepartmentFilter(admin.SimpleListFilter):
@@ -103,7 +104,7 @@ class DepartmentAdmin(admin.ModelAdmin):
 
     def department_union_link(self, item):
         url = reverse("admin:members_union_change", args=[item.union_id])
-        link = '<a href="%s">%s</a>' % (url, item.union.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.union.name))
         return mark_safe(link)
 
     department_union_link.short_description = "Forening"
@@ -111,7 +112,7 @@ class DepartmentAdmin(admin.ModelAdmin):
 
     def department_link(self, item):
         url = reverse("admin:members_department_change", args=[item.id])
-        link = '<a href="%s">%s</a>' % (url, item.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.name))
         return mark_safe(link)
 
     department_link.short_description = "Afdeling"

--- a/members/admin/union_admin.py
+++ b/members/admin/union_admin.py
@@ -4,6 +4,7 @@ from django.db.models.functions import Upper
 from django.http import HttpResponse
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.utils.html import escape
 
 from members.models import (
     Address,
@@ -107,7 +108,7 @@ class UnionAdmin(admin.ModelAdmin):
 
     def union_link(self, item):
         url = reverse("admin:members_union_change", args=[item.id])
-        link = '<a href="%s">%s</a>' % (url, item.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.name))
         return mark_safe(link)
 
     union_link.short_description = "Forening"

--- a/members/admin/waitinglist_admin.py
+++ b/members/admin/waitinglist_admin.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from django.shortcuts import render
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.utils.html import escape
 
 from members.models import (
     Union,
@@ -278,7 +279,7 @@ class WaitingListAdmin(admin.ModelAdmin):
 
     def union_link(self, item):
         url = reverse("admin:members_union_change", args=[item.id])
-        link = '<a href="%s">%s</a>' % (url, item.department.union.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.department.union.name))
         return mark_safe(link)
 
     union_link.short_description = "Forening"
@@ -286,7 +287,7 @@ class WaitingListAdmin(admin.ModelAdmin):
 
     def department_link(self, item):
         url = reverse("admin:members_department_change", args=[item.department_id])
-        link = '<a href="%s">%s</a>' % (url, item.department.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.department.name))
         return mark_safe(link)
 
     department_link.short_description = "Afdeling"
@@ -294,7 +295,7 @@ class WaitingListAdmin(admin.ModelAdmin):
 
     def person_link(self, item):
         url = reverse("admin:members_person_change", args=[item.person_id])
-        link = '<a href="%s">%s</a>' % (url, item.person.name)
+        link = '<a href="%s">%s</a>' % (url, escape(item.person.name))
         return mark_safe(link)
 
     person_link.short_description = "Person"


### PR DESCRIPTION
Relateret til https://github.com/CodingPirates/forenings_medlemmer/issues/880

Escape felter i admin views, så evt. HTML koder ikke renderes, da dette kunne være et sikkerhedshul. Søgte efter alle sider hvor vi sætter `link = '<a ...`

Test med html koder og unicode:
<img width="1047" alt="image" src="https://github.com/CodingPirates/forenings_medlemmer/assets/3763552/809c4bc1-b10f-4cd7-8d8e-761eef0f5dec">

