### PR TITLE
[#723] Redirect til familie oversigt efter oprettelse af barn

### DIFF
--- a/members/views/PersonCreate.py
+++ b/members/views/PersonCreate.py
@@ -21,7 +21,7 @@ def PersonCreate(request, membertype):
         form = PersonForm(request.POST, instance=person)
         if form.is_valid():
             UpdatePersonFromForm(person, form)
-            return HttpResponseRedirect(reverse("entry_page"))
+            return HttpResponseRedirect(reverse("family_detail"))
     else:
         person = Person()
         person.membertype = membertype


### PR DESCRIPTION
Relateret til [[Feature] Send forældre til Familie siden efter oprettelser af barn/værge/forældre](https://github.com/CodingPirates/forenings_medlemmer/issues/723)

Blot viderestil til familie oversigts side i stedet for forsiden, efter tilføjelse af barn
