### PR TITLE
[#975] Check for alder på dags dato om person kan inviteres til aktivitet

### DIFF
--- a/members/admin/admin_actions.py
+++ b/members/admin/admin_actions.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from dateutil.relativedelta import relativedelta
 from django import forms
 from django.contrib import admin
 from django.contrib import messages

--- a/members/admin/admin_actions.py
+++ b/members/admin/admin_actions.py
@@ -152,6 +152,8 @@ class AdminActions(admin.ModelAdmin):
                             with transaction.atomic():
                                 # for current_person in queryset:
                                 for current_person in persons:
+                                    person_age = current_person.age_years()
+
                                     # check for already participant
                                     if current_person.id in already_participant_ids:
                                         persons_already_participant.append(
@@ -165,21 +167,13 @@ class AdminActions(admin.ModelAdmin):
                                         )
 
                                     # Check for age constraint: too young ?
-                                    elif (
-                                        current_person.birthday
-                                        > activity.start_date
-                                        - relativedelta(years=activity.min_age)
-                                    ):
+                                    elif person_age < activity.min_age:
                                         persons_too_young.append(current_person.name)
+
                                     # Check for age constraint: too old ?
-                                    elif (
-                                        current_person.birthday
-                                        < activity.start_date
-                                        - relativedelta(
-                                            years=activity.max_age + 1, days=-1
-                                        )
-                                    ):
+                                    elif person_age > activity.max_age:
                                         persons_too_old.append(current_person.name)
+
                                     # Otherwise - person can be invited
                                     else:
                                         invited_counter = invited_counter + 1


### PR DESCRIPTION
Relateret til [#975 [BUG] Kan ikke invitere personer der er gamle nok](https://github.com/CodingPirates/forenings_medlemmer/issues/975)

Ændre til simpelthen blot at se på alder i forhold til dags dato, om person opfylder alderskrav.

Bemærk der nu udelukkende ses på dags dato, ikke i forhold til aktivitetens startdato. Dvs. der vil være børn som er blevet for gamle i mellemtiden, som ikke længere vil blive inviteret. Men i praksis er dette nok ikke et reelt problem, givet kun få børn bliver så længe

Har derudover rettet test logik en smule til, så det er nemmere at genkende test personer i forbindelse med debugging af test