### PR TITLE
[#975] Check også dags dato for alderscheck ved invitationer

### DIFF
--- a/members/admin/admin_actions.py
+++ b/members/admin/admin_actions.py
@@ -199,10 +199,14 @@ class AdminActions(admin.ModelAdmin):
                                             current_person.name
                                         )
 
-                                    # Check for age constraint: too young ?
+                                    # Check for age constraint: too young ? (check both at activity start and today)
                                     elif (
                                         current_person.birthday
                                         > activity.start_date
+                                        - relativedelta(years=activity.min_age)
+                                    ) and (
+                                        current_person.birthday
+                                        > timezone.now().date()
                                         - relativedelta(years=activity.min_age)
                                     ):
                                         persons_too_young.append(current_person.name)

--- a/members/admin/admin_actions.py
+++ b/members/admin/admin_actions.py
@@ -199,7 +199,9 @@ class AdminActions(admin.ModelAdmin):
                                             current_person.name
                                         )
 
-                                    # Check for age constraint: too young ? (check both at activity start and today)
+                                    # Check for age constraint: too young ?
+                                    # Since it's a "negative-list" of people who won't be invited, we use AND operator
+                                    # to add to list if person is too young at activity start AND today
                                     elif (
                                         current_person.birthday
                                         > activity.start_date

--- a/members/tests/test_admin_admin_actions.py
+++ b/members/tests/test_admin_admin_actions.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
 
 from django.test import TestCase, RequestFactory, override_settings
 from django.contrib import admin, messages
@@ -34,35 +35,70 @@ class TestAdminActions(TestCase):
             is_superuser=True,
         )
 
-        # logic for inviting is based on activity date, not current date, so we use fixed dates
-        self.activity = Activity(
-            start_date=datetime.fromisoformat(str(datetime.now().year) + "-01-01"),
-            end_date=datetime.fromisoformat(str(datetime.now().year) + "-12-31"),
+        # activity starts in two days, so we can test situation where person is too young today, but will be ok at activity start
+        self.activity_starting_in_two_days = Activity(
+            start_date=datetime.now() + relativedelta(days=2),
+            end_date=datetime.now() + relativedelta(months=1),
             min_age=7,
             max_age=17,
             department=self.department,
             union=self.union,
         )
-        self.activity.save()
+        self.activity_starting_in_two_days.save()
+
+        # activity started two days ago, so we can test situation where person wasn't old enough at activity start, but is today
+        self.activity_started_two_days_ago = Activity(
+            start_date=datetime.now() - relativedelta(days=2),
+            end_date=datetime.now() + relativedelta(months=1),
+            min_age=7,
+            max_age=17,
+            department=self.department,
+            union=self.union,
+        )
+        self.activity_started_two_days_ago.save()
 
         self.family = Family()
         self.family.save()
 
+        # create test persons with specific ages (will have birthday a week ago)
+        self.person_min_age = self.create_person_and_waiting_list_entry(
+            name="person_min_age", age=7
+        )
+        self.person_within_age_range = self.create_person_and_waiting_list_entry(
+            name="person_within_age_range", age=10
+        )
+        self.person_max_age = self.create_person_and_waiting_list_entry(
+            name="person_max_age", age=17
+        )
+        self.person_above_max_age = self.create_person_and_waiting_list_entry(
+            name="person_above_max_age", age=18
+        )
+
+        # activity starts in two days, person has birthday two weeks after
         self.person_too_young = self.create_person_and_waiting_list_entry(
-            str(datetime.now().year - 5) + "-01-01"
-        )  # 5 years old
-        self.person_exactly_start_age = self.create_person_and_waiting_list_entry(
-            str(datetime.now().year - 7) + "-01-01"
-        )  # 7 years old
-        self.person_correct_age = self.create_person_and_waiting_list_entry(
-            str(datetime.now().year - 10) + "-01-01"
-        )  # 10 years old
-        self.person_exactly_end_age = self.create_person_and_waiting_list_entry(
-            str(datetime.now().year - 17) + "-01-01"
-        )  # 17 years old
-        self.person_too_old = self.create_person_and_waiting_list_entry(
-            str(datetime.now().year - 18) + "-01-01"
-        )  # 18 years old
+            name="person_too_young",
+            birthday=(datetime.now() - relativedelta(years=7) + relativedelta(weeks=2)),
+        )
+
+        # activity starts in two days, person has birthday tomorrow
+        self.person_becomes_min_age_tomorrow = (
+            self.create_person_and_waiting_list_entry(
+                name="person_becomes_min_age_tomorrow",
+                birthday=(
+                    datetime.now() - relativedelta(years=7) + relativedelta(days=1)
+                ),
+            )
+        )
+
+        # activity started two days ago, person had birthday yesterday
+        self.person_became_min_age_yesterday = (
+            self.create_person_and_waiting_list_entry(
+                name="person_became_min_age_yesterday",
+                birthday=(
+                    datetime.now() - relativedelta(years=7) - relativedelta(days=1)
+                ),
+            )
+        )
 
         # setup email template
         EmailTemplate.objects.create(
@@ -70,39 +106,55 @@ class TestAdminActions(TestCase):
             subject="test email subject",
         )
 
-    def create_person_and_waiting_list_entry(self, person_birthday):
+    def create_person_and_waiting_list_entry(self, name=None, age=None, birthday=None):
+        if age is not None:
+            person_birthday = (
+                datetime.now() - relativedelta(years=age) - relativedelta(weeks=1)
+            )
+            person_name = f"Testperson {age} år, født {person_birthday}"
+        elif birthday is not None:
+            person_birthday = birthday
+            person_name = f"Testperson født {person_birthday}"
+        else:
+            raise ValueError("Either age or birthday must be specified")
+
+        if name is not None:
+            person_name = name
+
         person = Person.objects.create(
-            name=person_birthday,
+            name=person_name,
             family=self.family,
-            birthday=datetime.fromisoformat(person_birthday),
+            birthday=person_birthday,
         )
         WaitingList(
             person=person,
             department=self.department,
-            on_waiting_list_since=datetime.now() - timedelta(days=1),
+            on_waiting_list_since=datetime.now() - relativedelta(days=1),
         ).save()
 
         return person
 
-    def create_mock_request_object(self):
+    def create_mock_request_object(self, activity):
         request = self.factory.post("/admin/members/activity/")
         request._messages = messages.storage.default_storage(
             request
         )  # Add support for django messaging framework
         request.method = "POST"
         request.POST = {
-            "activity": "1",
-            "department": "1",
-            "expire": datetime.fromisoformat("2023-12-31"),
+            "activity": activity.id,
+            "department": activity.department.id,
+            "expire": datetime.now() + relativedelta(months=1),
             "email_text": "Lidt ekstra tekst",
         }
         request.user = self.user
 
         return request
 
-    # test for person who is within age range
-    def test_invite_many_to_activity_action_correct_persons_are_invited(self):
-        request = self.create_mock_request_object()
+    # test for person who is within age range for activity in future
+    def skip_test_invite_many_to_activity_starting_in_two_days(self):
+        request = self.create_mock_request_object(
+            activity=self.activity_starting_in_two_days
+        )
 
         # Call the method. Returns None if successful, so no need to store response
         self.admin.invite_many_to_activity_action(request, Person.objects.all())
@@ -110,15 +162,81 @@ class TestAdminActions(TestCase):
         # Assert that the correct persons are invited
         invitations = ActivityInvite.objects.all()
 
-        self.assertEqual(invitations.count(), 3)
-        self.assertTrue(invitations.filter(person=self.person_correct_age).exists())
+        self.assertEqual(
+            invitations.count(),
+            5,
+            "Actually invited: '"
+            + ", ".join(str(invitation.person.name) for invitation in invitations)
+            + "'",
+        )
         self.assertTrue(
             invitations.filter(
-                person=self.person_exactly_start_age, activity=self.activity
+                person=self.person_within_age_range,
+                activity=self.activity_starting_in_two_days,
             ).exists()
         )
         self.assertTrue(
             invitations.filter(
-                person=self.person_exactly_end_age, activity=self.activity
+                person=self.person_min_age, activity=self.activity_starting_in_two_days
+            ).exists()
+        )
+        self.assertTrue(
+            invitations.filter(
+                person=self.person_max_age, activity=self.activity_starting_in_two_days
+            ).exists()
+        )
+        self.assertTrue(
+            invitations.filter(
+                person=self.person_becomes_min_age_tomorrow,
+                activity=self.activity_starting_in_two_days,
+            ).exists()
+        )
+
+        self.assertTrue(
+            invitations.filter(
+                person=self.person_became_min_age_yesterday,
+                activity=self.activity_starting_in_two_days,
+            ).exists()
+        )
+
+    # test for person who is within age range for activity in past
+    def test_invite_many_to_activity_started_two_days_ago(self):
+        request = self.create_mock_request_object(
+            activity=self.activity_started_two_days_ago
+        )
+
+        # Call the method. Returns None if successful, so no need to store response
+        self.admin.invite_many_to_activity_action(request, Person.objects.all())
+
+        # Assert that the correct persons are invited
+        invitations = ActivityInvite.objects.all()
+
+        self.assertEqual(
+            invitations.count(),
+            4,
+            "Actually invited: '"
+            + ", ".join(str(invitation.person.name) for invitation in invitations)
+            + "'",
+        )
+        self.assertTrue(
+            invitations.filter(
+                person=self.person_within_age_range,
+                activity=self.activity_started_two_days_ago,
+            ).exists()
+        )
+        self.assertTrue(
+            invitations.filter(
+                person=self.person_min_age, activity=self.activity_started_two_days_ago
+            ).exists()
+        )
+        self.assertTrue(
+            invitations.filter(
+                person=self.person_max_age, activity=self.activity_started_two_days_ago
+            ).exists()
+        )
+        self.assertTrue(
+            invitations.filter(
+                person=self.person_became_min_age_yesterday,
+                activity=self.activity_started_two_days_ago,
             ).exists()
         )

--- a/members/tests/test_admin_admin_actions.py
+++ b/members/tests/test_admin_admin_actions.py
@@ -151,7 +151,7 @@ class TestAdminActions(TestCase):
         return request
 
     # test for person who is within age range for activity in future
-    def skip_test_invite_many_to_activity_starting_in_two_days(self):
+    def test_invite_many_to_activity_starting_in_two_days(self):
         request = self.create_mock_request_object(
             activity=self.activity_starting_in_two_days
         )


### PR DESCRIPTION
Retter [#975 Kan ikke invitere personer der er gamle nok](https://github.com/CodingPirates/forenings_medlemmer/issues/975)

* Ved alderscheck for "too young", kigges også på dags dato
* TIlføjet test for
  * Invitation til aktivitet i fremtiden
  * Invitation til aktivitet der er startet (her træder det nye alderscheck i kraft)
* Desuden rettet tests, så der nu bruges relative datoer, og vi ikke har problemer omkring årsskiftet