### PR TITLE
Update emailitem.py

### DIFF
--- a/members/management/commands/correct_email_content.py
+++ b/members/management/commands/correct_email_content.py
@@ -1,0 +1,31 @@
+from django.core.management.base import BaseCommand
+from members.models.emailitem import EmailItem
+from django.db.models import Q
+
+
+class Command(BaseCommand):
+    help = "Update Email content to avoid special characters like curly brackets"
+
+    def handle(self, *args, **options):
+        print(f"Starting: {help}")
+        for email in EmailItem.objects.filter(
+            Q(subject__contains="{") | Q(subject__contains="}")
+        ):
+            print(f"Correcting subject: {email.subject}")
+            email.subject = email.subject.replace("{", "").replace("}", "")
+            email.save()
+
+        for email in EmailItem.objects.filter(
+            Q(body_html__contains="{") | Q(body_html__contains="}")
+        ):
+            print(f"Correcting body_html:\n{email.body_html}\n")
+            email.body_html = email.body_html.replace("{", "").replace("}", "")
+            email.save()
+
+        for email in EmailItem.objects.filter(
+            Q(body_text__contains="{") | Q(body_text__contains="}")
+        ):
+            print(f"Correcting body_text:\n{email.body_text}\n")
+            email.body_text = email.body_text.replace("{", "").replace("}", "")
+            email.save()
+        print("Finished")

--- a/members/models/emailitem.py
+++ b/members/models/emailitem.py
@@ -67,9 +67,7 @@ class EmailItem(models.Model):
     def subject_and_email(self, format_as_html: bool):
         if format_as_html:
             return format_html(
-                f'<div title="{escape(self.body_html)}">{self.subject}</div>'.replace(
-                    "{", ""
-                ).replace("}", "")
+                f'<div title="{escape(self.body_html)}">{self.subject}</div>'
             )
         else:
             return f"Subject:{self.subject}\nEmail:\n{self.body_text}"

--- a/members/models/emailitem.py
+++ b/members/models/emailitem.py
@@ -67,7 +67,9 @@ class EmailItem(models.Model):
     def subject_and_email(self, format_as_html: bool):
         if format_as_html:
             return format_html(
-                f'<div title="{escape(self.body_html)}">{self.subject}</div>'.replace("{","").replace("}","")
+                f'<div title="{escape(self.body_html)}">{self.subject}</div>'.replace(
+                    "{", ""
+                ).replace("}", "")
             )
         else:
             return f"Subject:{self.subject}\nEmail:\n{self.body_text}"

--- a/members/models/emailitem.py
+++ b/members/models/emailitem.py
@@ -67,7 +67,7 @@ class EmailItem(models.Model):
     def subject_and_email(self, format_as_html: bool):
         if format_as_html:
             return format_html(
-                f'<div title="{escape(self.body_html)}">{self.subject}</div>'
+                f'<div title="{escape(self.body_html)}">{self.subject}</div>'.replace("{","").replace("}","")
             )
         else:
             return f"Subject:{self.subject}\nEmail:\n{self.body_text}"

--- a/members/models/emailtemplate.py
+++ b/members/models/emailtemplate.py
@@ -126,13 +126,21 @@ class EmailTemplate(models.Model):
             context = Context(context)
 
             # render the template
-            html_template = Engine.get_default().from_string(self.body_html)
-            text_template = Engine.get_default().from_string(self.body_text)
-            subject_template = Engine.get_default().from_string(self.subject)
-
-            html_content = html_template.renderAndValidate(context)
-            text_content = text_template.renderAndValidate(context)
-            subject_content = subject_template.renderAndValidate(context)
+            html_template = (
+                Engine.get_default()
+                .from_string(self.body_html)
+                .renderAndValidate(context)
+            )
+            text_template = (
+                Engine.get_default()
+                .from_string(self.body_text)
+                .renderAndValidate(context)
+            )
+            subject_template = (
+                Engine.get_default()
+                .from_string(self.subject)
+                .renderAndValidate(context)
+            )
 
             if (
                 allow_multiple_emails

--- a/members/models/emailtemplate.py
+++ b/members/models/emailtemplate.py
@@ -126,17 +126,17 @@ class EmailTemplate(models.Model):
             context = Context(context)
 
             # render the template
-            html_template = (
+            html_content = (
                 Engine.get_default()
                 .from_string(self.body_html)
                 .renderAndValidate(context)
             )
-            text_template = (
+            text_content = (
                 Engine.get_default()
                 .from_string(self.body_text)
                 .renderAndValidate(context)
             )
-            subject_template = (
+            subject_content = (
                 Engine.get_default()
                 .from_string(self.subject)
                 .renderAndValidate(context)

--- a/members/models/emailtemplate.py
+++ b/members/models/emailtemplate.py
@@ -126,21 +126,13 @@ class EmailTemplate(models.Model):
             context = Context(context)
 
             # render the template
-            html_content = (
-                Engine.get_default()
-                .from_string(self.body_html)
-                .renderAndValidate(context)
-            )
-            text_content = (
-                Engine.get_default()
-                .from_string(self.body_text)
-                .renderAndValidate(context)
-            )
-            subject_content = (
-                Engine.get_default()
-                .from_string(self.subject)
-                .renderAndValidate(context)
-            )
+            html_content = Engine.get_default().from_string(self.body_html)
+            text_content = Engine.get_default().from_string(self.body_text)
+            subject_content = Engine.get_default().from_string(self.subject)
+
+            html_content = self.renderAndValidate(html_content, context)
+            text_content = self.renderAndValidate(text_content, context)
+            subject_content = self.renderAndValidate(subject_content, context)
 
             if (
                 allow_multiple_emails
@@ -168,9 +160,8 @@ class EmailTemplate(models.Model):
                 emails.append(email)
         return emails
 
-
-    def renderAndValidate(self, context):
-        rendered = self.render(context)
+    def renderAndValidate(self, template, context):
+        rendered = template.render(context)
         validated = rendered.replace("{", "").replace("}", "")
 
         return validated

--- a/members/models/emailtemplate.py
+++ b/members/models/emailtemplate.py
@@ -130,14 +130,9 @@ class EmailTemplate(models.Model):
             text_template = Engine.get_default().from_string(self.body_text)
             subject_template = Engine.get_default().from_string(self.subject)
 
-            html_content = html_template.render(context)
-            text_content = text_template.render(context)
-            subject_content = subject_template.render(context)
-
-            # strip invalid characters like curly brackets
-            html_content = html_content.replace("{", "").replace("}", "")
-            text_content = text_content.replace("{", "").replace("}", "")
-            subject_content = subject_content.replace("{", "").replace("}", "")
+            html_content = html_template.renderAndValidate(context)
+            text_content = text_template.renderAndValidate(context)
+            subject_content = subject_template.renderAndValidate(context)
 
             if (
                 allow_multiple_emails
@@ -164,3 +159,9 @@ class EmailTemplate(models.Model):
                 email.save()
                 emails.append(email)
         return emails
+
+def renderAndValidate(self, context):
+    rendered = self.render(context)
+    validated = rendered.replace("{", "").replace("}", "")
+
+    return validated

--- a/members/models/emailtemplate.py
+++ b/members/models/emailtemplate.py
@@ -133,6 +133,12 @@ class EmailTemplate(models.Model):
             html_content = html_template.render(context)
             text_content = text_template.render(context)
             subject_content = subject_template.render(context)
+
+            # strip invalid characters like curly brackets
+            html_content = html_content.replace("{", "").replace("}", "")
+            text_content = text_content.replace("{", "").replace("}", "")
+            subject_content = subject_content.replace("{", "").replace("}", "")
+
             if (
                 allow_multiple_emails
                 or members.models.emailitem.EmailItem.objects.filter(

--- a/members/models/emailtemplate.py
+++ b/members/models/emailtemplate.py
@@ -160,6 +160,7 @@ class EmailTemplate(models.Model):
                 emails.append(email)
         return emails
 
+
 def renderAndValidate(self, context):
     rendered = self.render(context)
     validated = rendered.replace("{", "").replace("}", "")

--- a/members/models/emailtemplate.py
+++ b/members/models/emailtemplate.py
@@ -169,8 +169,8 @@ class EmailTemplate(models.Model):
         return emails
 
 
-def renderAndValidate(self, context):
-    rendered = self.render(context)
-    validated = rendered.replace("{", "").replace("}", "")
+    def renderAndValidate(self, context):
+        rendered = self.render(context)
+        validated = rendered.replace("{", "").replace("}", "")
 
-    return validated
+        return validated


### PR DESCRIPTION
Hvis body_html indeholder en { eller en }, så sker der en fejl 500. Der er nogle emails hvor man har haft brug af en ugyldig variable, f.x. {union.name}. Nu fjernes { og } ifm visning af body_html i Admin > Famile (og dernæst vælge en familie)