### PR TITLE
[#1028] Viderestil ikke url ved login, hvis kommer fra logout side

### DIFF
--- a/members/templates/members/header.html
+++ b/members/templates/members/header.html
@@ -18,7 +18,7 @@
     {% else %}
         <a href="{% url "account_create" %}">Tilmeld barn</a>
         <a href="{% url "volunteer_signup" %}">Bliv frivillig</a>
-        <a id="login-logout" href="{% url 'person_login' %}?next={{request.path}}">Log ind</a>
+        <a id="login-logout" href="{% url 'person_login' %}{% if not 'logout' in request.path %}?next={{request.path}}{% endif %}">Log ind</a>
     {% endif %}
     <a href="https://codingpirates.dk" target="_blank">
         <img src="{% static "logo.png" %}"/>


### PR DESCRIPTION
Se #1028 

Hvis bruger lige havde logget ud, og ville logge ind igen, blev man viderestillet til logout, og det kunne man så gøre et stykke tid...

Rettelsen er blot ikke at viderestille hvis man trykker på "Log ind" link fra logout siden