### PR TITLE
Updated to actions/upload-artifact@v4.4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
         run: docker compose run web flake8
       - name: Test
         run: docker compose run web ./manage.py test
-      - uses: actions/upload-artifact@v2.1.4
+      - uses: actions/upload-artifact@v4.4.0
         if: always()
         with:
           name: selenium-screens
           path: ./test-screens
       - name: Create and upload UML diagram
         run: mkdir -p UML && docker compose run web ./manage.py graph_models members -o UML/UML_diagram.png
-      - uses: actions/upload-artifact@v2.1.4
+      - uses: actions/upload-artifact@v4.4.0
         with:
           name: UML_diagram.png
           path: UML


### PR DESCRIPTION
Fik fejl i https://github.com/CodingPirates/forenings_medlemmer/actions/runs/10890213124/job/30218456052?pr=1107
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2.1.4`.
Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```