### PR TITLE
Tilføjet Docker Compose fil for ARM64, samt fjernet obsolete version felt

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,7 +13,8 @@ You are more than welcome to contribute to the system. This guide documents how 
 - The setup adheres to the [twelve-factor-app][12f] principles. To get a
     local development configuration, copy the file `.env.example` to `.env`
 
-- Run `docker compose up` to start your local system.
+- Run `docker compose up` to start your local system.  
+  (If on Apple Silicon machine, run `docker compose -f docker-compose.yml -f docker-compose.arm64.yml up --build`)
 
 - Run `docker compose run web ./manage.py get_live_data` to download public
     data and insert it into your local database.

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,0 +1,11 @@
+# use this file as override, if on Arm64 architecture, e.g. Mac M1
+# example commands:
+# - docker compose -f docker-compose.yml -f docker-compose.arm64.yml up --build
+# - docker compose -f docker-compose.yml -f docker-compose.arm64.yml run --build web ./manage.py test
+services:
+  selenium:
+    image: seleniarm/standalone-chromium
+    networks:
+      - webnet
+    ports:
+      - "4444:4444"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
   web:
     build: .


### PR DESCRIPTION
* Fjernet `version` felt fra `docker-compose.yml`, for at undgå følgende advarsel:
   ```
   WARN[0000] /Users/rasmus/src/github.com/CodingPirates/forenings_medlemmer/docker-compose.yml:
   the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
   ```
* Tilføjet Docker Compose fil til brug på Apple M1 (ARM64) maskiner, samt tilføjet beskrivelse til contributing guide. I fald andre kører ARM64