### PR TITLE
Sæt package-mode = false i pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ target-version = ['py310', 'py311']
 omit = ["*/tests/*", "members/migrations"]
 
 [tool.poetry]
+package-mode = false
 name = "forenings_medlemmer"
 version = "1.2"
 description = "Forenings system for Coding Pirates"


### PR DESCRIPTION
Vi oplevede pludselig at [builds fejlede](https://github.com/CodingPirates/forenings_medlemmer/actions/runs/12732354292/job/35487437263) med
```
Error: The current project could not be installed: No file/folder found for package forenings-medlemmer
```
Tilsyneladende har noget ændret sig i Poetry. I hvert fald ifølge https://python-poetry.org/docs/basic-usage/#operating-modes, ser det ud til at eftersom vi ikke bygger en pakke, kan vi sætte `package-mode = false`