### PR TITLE
Optimer visning af "anonymiserings kandidater" liste

### DIFF
--- a/members/admin/anonymization_candidates_admin.py
+++ b/members/admin/anonymization_candidates_admin.py
@@ -9,9 +9,9 @@ from members.models import ActivityParticipant
 from .person_admin import PersonAdmin
 
 
-class IsAnonymizationCandidateFilter(admin.SimpleListFilter):
+class IsActiveFilter(admin.SimpleListFilter):
     title = "Aktiv"
-    parameter_name = "is_candidate"
+    parameter_name = "is_active"
 
     def lookups(self, request, model_admin):
         return (
@@ -20,19 +20,53 @@ class IsAnonymizationCandidateFilter(admin.SimpleListFilter):
         )
 
     def queryset(self, request, queryset):
+        from django.utils import timezone
+        from datetime import timedelta
+        from django.db.models import Q
+
+        five_years_ago = timezone.now() - timedelta(days=5 * 365)
+
         if self.value() == "no":
-            # show members that hasn't been active in the last 5 years
-            person_ids = [
-                person.id for person in queryset if person.is_anonymization_candidate()
-            ]
-            return queryset.filter(id__in=person_ids)
+            # Show members that haven't been active in the last 5 years (anonymization candidates)
+            # This is the optimized database query version of is_anonymization_candidate()
+
+            return (
+                queryset.filter(
+                    # Person was created more than 5 years ago
+                    added_at__lt=five_years_ago
+                )
+                .filter(
+                    # AND (no user OR user hasn't logged in within 5 years)
+                    Q(user__isnull=True)
+                    | Q(user__last_login__lt=five_years_ago)
+                )
+                .filter(
+                    # AND (no activity participation OR latest activity was more than 5 years ago)
+                    ~Q(
+                        activityparticipant__activity__end_date__gte=five_years_ago.date()
+                    )
+                )
+                .distinct()
+            )
+
         elif self.value() == "yes":
-            person_ids = [
-                person.id
-                for person in queryset
-                if not person.is_anonymization_candidate()
-            ]
-            return queryset.filter(id__in=person_ids)
+            # Show members that have been active in the last 5 years (not anonymization candidates)
+
+            return queryset.filter(
+                Q(
+                    # Person was created less than 5 years ago
+                    added_at__gte=five_years_ago
+                )
+                | Q(
+                    # OR user has logged in within 5 years
+                    user__last_login__gte=five_years_ago
+                )
+                | Q(
+                    # OR has activity participation within 5 years
+                    activityparticipant__activity__end_date__gte=five_years_ago.date()
+                )
+            ).distinct()
+
         return queryset
 
 
@@ -59,14 +93,14 @@ class AnonymizationCandidatesAdmin(PersonAdmin):
 
     # Filters for the anonymization candidates view
     list_filter = (
-        "membertype",  # Type
-        IsAnonymizationCandidateFilter,  # person.is_candidate
+        "membertype",
+        IsActiveFilter,
     )
 
     # Custom actions for this view
     actions = [
         "export_anonymization_candidates_csv",
-        "anonymize_persons",  # Reuse existing anonymization action
+        "anonymize_persons",
     ]
 
     # Override title and description


### PR DESCRIPTION
Brug query filter i stedet for at kalde `person.is_anonymization_candidate()` for hver person. Har testet lokalt med 10.000 personer, og er mærkbart hurtigere.

Selve visningen kalder stadig `person.is_anonymization_candidate()` for at vise farven, så man vil se hvis filter skulle have inkluderet en forkert person