### PR TITLE
Ændre tekst når man tilmelder sig, til ikke at indeholde ordet 'barn'

### DIFF
--- a/members/forms/activity_signup_form.py
+++ b/members/forms/activity_signup_form.py
@@ -88,7 +88,7 @@ class ActivitySignupForm(forms.Form):
 
     note = forms.CharField(
         label=mark_safe(
-            "<span style='color:red'><b>Ekstra information:</b></span> Har deltageren nogle behov?"
+            "<span style='color:red'><b>Ekstra information:</b></span> Har den tilmeldte person nogle behov?"
         ),
         widget=forms.Textarea,
         required=False,


### PR DESCRIPTION
Baseret på bruger feedback, det er forvirrende at der står "barn", hvis man f.eks. tilmelder sig selv til landsmødet.

Ændringer:
<img width="1297" height="546" alt="image" src="https://github.com/user-attachments/assets/e21718af-7d63-4fde-a175-2b64b4825578" />
