### PR TITLE
I Admin UI, tillad at anonymisere personer selvom de har været logget ind seneste 2 år

### DIFF
--- a/members/admin/person_admin.py
+++ b/members/admin/person_admin.py
@@ -343,7 +343,9 @@ class PersonAdmin(admin.ModelAdmin):
                 context["mass_confirmation_form"] = form
                 for person in queryset:
                     try:
-                        person.anonymize(request)
+                        # from Admin UI, allow anonymizing even if person has been logged in or created recently
+                        # likely this is by request from user
+                        person.anonymize(request, relaxed=True)
                     except Exception as e:
                         self.message_user(
                             request,


### PR DESCRIPTION
Se #1333 

Fra Admin UI er det sandsynligvis efter ønske fra personen selv at der skal anonymiseres, så tillad selvom der er login for nyligt. Kræver stadig at seneste økonomiske transaktion er over 5 år siden