### PR TITLE
Remove unnecessary print() statements from batch job, as they are cluttering test output

### DIFF
--- a/members/management/commands/cron_job_send_activityinvite_reminders.py
+++ b/members/management/commands/cron_job_send_activityinvite_reminders.py
@@ -13,7 +13,6 @@ class Command(BaseCommand):
     help = "Send activity invite reminders"
 
     def handle(self, *args, **options):
-        print("Sending activity invite reminders")
         template_name = "ACT_INVITE"
         try:
             template = EmailTemplate.objects.get(idname=template_name)
@@ -52,10 +51,6 @@ class Command(BaseCommand):
                 "person": invite.person,
                 "family": invite.person.family,
             }
-            print(
-                f"Sending reminder for activity '{invite.activity.department.name}/{invite.activity.name}' "
-                f"to invite id {invite.id}"
-            )
             template.makeEmail(
                 [invite.person.family], context, allow_multiple_emails=True
             )


### PR DESCRIPTION
We can see from Emails which e-mail were actually sent, no need for these print() statements

```
Found 125 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
Sending activity invite reminders
Sending activity invite reminders
Sending activity invite reminders
Sending activity invite reminders
Sending activity invite reminders
Sending reminder for activity 'Jasonhavn/Efterårssæson 1996' to invite id 14
.............................................................................................................................
----------------------------------------------------------------------
Ran 125 tests in 58.346s
```