### PR TITLE
Fix flaky tests

### DIFF
--- a/members/admin/activity_admin.py
+++ b/members/admin/activity_admin.py
@@ -10,6 +10,7 @@ from django.utils.html import escape, format_html
 from django.utils.safestring import mark_safe
 
 # from members.admin.admin_actions import export_participants_csv
+from forenings_medlemmer.settings import MINIMUM_SEASON_PRICE_IN_DKK
 from members.admin.admin_actions import AdminActions
 from members.forms.season_fee_update_form import SeasonFeeUpdateForm
 from members.models import (
@@ -297,7 +298,7 @@ class ActivityAdmin(admin.ModelAdmin):
         # Only set season_fee to default if no override reason is given
         if not obj.season_fee_change_reason:
             if obj.activitytype_id == "FORLØB":
-                obj.season_fee = 150
+                obj.season_fee = MINIMUM_SEASON_PRICE_IN_DKK
             else:
                 obj.season_fee = 0
         # else: keep the user-set value (with reason)

--- a/members/models/activity.py
+++ b/members/models/activity.py
@@ -43,7 +43,7 @@ class Activity(models.Model):
         default=None,
         null=True,
         blank=True,
-        help_text="""Standard er 150 kr for sæson/forløb, 0 kr for Arrangementer og Støttemedlemskaber.<br>Beregnes automatisk ved oprettelse af aktiviteten.""",
+        help_text=f"""Standard er {ACTIVITY_MIN_AMOUNT} kr for sæson/forløb, 0 kr for Arrangementer og Støttemedlemskaber.<br>Beregnes automatisk ved oprettelse af aktiviteten.""",
     )
     season_fee_change_reason = models.CharField(
         "Begrundelse for ændring af sæsonbidrag",
@@ -190,7 +190,7 @@ class Activity(models.Model):
                 errors["end_date"] = "Et arrangement kan maksimalt vare 14 dage."
 
         if self.activitytype and self.activitytype.id == "FORLØB":
-            default_fee = 150
+            default_fee = settings.MINIMUM_SEASON_PRICE_IN_DKK
         else:
             default_fee = 0
 

--- a/members/tests/factories/activity_factory.py
+++ b/members/tests/factories/activity_factory.py
@@ -1,5 +1,6 @@
 import factory
 import random
+from forenings_medlemmer.settings import MINIMUM_SEASON_PRICE_IN_DKK
 from members.tests.factories.factory_helpers import TIMEZONE, LOCALE
 from members.tests.factories.providers import DanishProvider, CodingPiratesProvider
 from members.models import Activity
@@ -49,7 +50,7 @@ class ActivityFactory(DjangoModelFactory):
     )
     updated_dtm = Faker("date_time", tzinfo=TIMEZONE)
     open_invite = Faker("boolean")
-    price_in_dkk = Faker("random_number", digits=4)
+    price_in_dkk = Faker("random_int", min=MINIMUM_SEASON_PRICE_IN_DKK, max=9999)
     max_participants = Faker("random_number")
     min_age = Faker("random_int", min=5, max=18)
     max_age = LazyAttribute(lambda a: a.min_age + random.randint(10, 80))

--- a/members/tests/test_functional/test_account_create.py
+++ b/members/tests/test_functional/test_account_create.py
@@ -4,6 +4,7 @@ import time
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
@@ -159,6 +160,12 @@ class AccountCreateTest(StaticLiveServerTestCase):
         self.browser.find_element(By.XPATH, "//input[@type='submit']").click()
 
         # Check that we were redirectet to front page
+        try:
+            WebDriverWait(self.browser, 10).until(
+                EC.url_to_be(f"{self.live_server_url}/")
+            )
+        except TimeoutException:
+            pass  # fall through so assertEqual gives a clear url diff
         self.assertEqual(f"{self.live_server_url}/", self.browser.current_url)
 
     def test_account_create_without_redirect(self):


### PR DESCRIPTION
Så tidligere følgende fejlende tests nogen gange:

Forløbspris < 150 kr:
```
Found 126 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...F..........................................................................................................................
======================================================================
FAIL: test_invite_many_to_activity_starting_in_two_days (members.tests.test_admin_admin_actions.TestAdminActions.test_invite_many_to_activity_starting_in_two_days)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/app/members/tests/test_admin_admin_actions.py", line 174, in test_invite_many_to_activity_starting_in_two_days
    self.assertEqual(
AssertionError: 0 != 5 : Actually invited: ''

----------------------------------------------------------------------
Ran 126 tests in 57.322s
```

Browser url ikke opdateret endnu:
```
RUNNING IN DEBUG MODE
Found 125 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
...............................................................................................................F.............
======================================================================
FAIL: test_account_create_without_redirect (members.tests.test_functional.test_account_create.AccountCreateTest.test_account_create_without_redirect)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/app/members/tests/test_functional/test_account_create.py", line 173, in test_account_create_without_redirect
    self.login_and_assert_frontpage_redirect_ui_flow()
  File "/app/members/tests/test_functional/test_account_create.py", line 162, in login_and_assert_frontpage_redirect_ui_flow
    self.assertEqual(f"{self.live_server_url}/", self.browser.current_url)
AssertionError: 'http://172.19.0.4:43361/' != 'http://172.19.0.4:43361/account/login/'
- http://172.19.0.4:43361/
+ http://172.19.0.4:43361/account/login/
?                         ++++++++++++++


----------------------------------------------------------------------
Ran 125 tests in 65.356s

FAILED (failures=1)
```

Rettet ved hhv:
* `activity_factory` sætter mindste pris til 150 kr (samt rette et par andre steder, hvor vi brugte prisen direkte)
* vent op til 10 sekunder på browser er opdateret