### PR TITLE
[1300] Tilføjet GDPR relateret tekst til foto-tilladelse

### DIFF
--- a/members/forms/activity_signup_form.py
+++ b/members/forms/activity_signup_form.py
@@ -94,7 +94,7 @@ class ActivitySignupForm(forms.Form):
         required=False,
     )
     photo_permission = forms.ChoiceField(
-        label="Må Coding Pirates tage og bruge billeder og videoer af den tilmeldte person på aktiviteten? (Billederne lægges typisk på vores hjemmeside og Facebook side)",
+        label="Må Coding Pirates tage og bruge billeder og videoer af den tilmeldte person på aktiviteten? (Billederne lægges typisk på vores hjemmeside og Facebook side, og kan også deles med en evt. samarbejdspartner, vi afholder aktiviteten sammen med)",
         initial="Choose",
         required=True,
         choices=(


### PR DESCRIPTION
Se #1300

Følgende tekst er tilføjet:
<img width="1258" height="803" alt="image" src="https://github.com/user-attachments/assets/8bc0e164-dcd4-4e6e-a784-8eeb6e749e0f" />
