### PR TITLE
Vis ikke 'Afslå invitation' for åbne aktiviteter

### DIFF
--- a/members/forms/activity_signup_form.py
+++ b/members/forms/activity_signup_form.py
@@ -79,7 +79,7 @@ class ActivitySignupForm(forms.Form):
                                     css_class="button-success",
                                 ),
                                 HTML(
-                                    "<a class='button-danger' href='{% url 'invitation_decline' invitation.decline_uuid invitation.id %}'>Afslå invitation</a>"
+                                    "{% if invitation %}<a class='button-danger' href='{% url 'invitation_decline' invitation.decline_uuid invitation.id %}'>Afslå invitation</a>{% endif %}"
                                 ),
                                 style="display: flex; align-items: center;",
                             ),


### PR DESCRIPTION
Ved åben aktivitet, fejlede siden med
```
NoReverseMatch at /family/activity/5/person/188/

Error during template rendering
In template <unknown source>, error at line 1

Reverse for 'invitation_decline' with arguments '('', '')' not found. 1 pattern(s) tried: ['family/(?P<decline_uuid>[\\w-]+)/invitation_decline/(?P<invitation_id>[\\d]+)/$']
1	<a class='button-danger' href='{% url 'invitation_decline' invitation.decline_uuid invitation.id %}'>Afslå invitation</a>
```

Genskabt lokalt. Ved åben aktivitet er der ikke en invitation, så vi skal ikke vise "Afslå invitation" knappen